### PR TITLE
Get username by email

### DIFF
--- a/examples/get_username_by_email/main.go
+++ b/examples/get_username_by_email/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	u, err := c.GetUsernameByEmail(context.TODO(), "kenzo.tanaka@example.com")
+	if err != nil {
+		return err
+	}
+	log.Printf("user: %#v\n", u)
+	return nil
+}

--- a/teammate.go
+++ b/teammate.go
@@ -45,6 +45,21 @@ func (c *Client) GetTeammate(ctx context.Context, username string) (*User, error
 	return user, nil
 }
 
+func (c *Client) GetUsernameByEmail(ctx context.Context, email string) (username string, err error) {
+	users, err := c.GetTeammates(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	for _, user := range users {
+		if user.Email != email {
+			continue
+		}
+		username = user.Username
+	}
+	return username, nil
+}
+
 func (c *Client) GetTeammates(ctx context.Context) ([]*User, error) {
 	req, err := c.NewRequest("GET", "/teammates", nil)
 	if err != nil {

--- a/teammate_test.go
+++ b/teammate_test.go
@@ -135,6 +135,47 @@ func TestGetTeammate_Failed(t *testing.T) {
 	}
 }
 
+func TestGetUsernameByEmail(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONTeammates); err != nil {
+			t.Fatal(err)
+		}
+	})
+	mux.HandleFunc("/teammates/username", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONTeammate); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetUsernameByEmail(context.TODO(), "kenzo.tanaka@example.com")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := "kenzo.tanaka"
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetUsernameByEmail_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetUsernameByEmail(context.TODO(), "kenzo.tanaka@example.com")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
 func TestGetTeammates(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
retrieve the username of a teammate using their email address.

While inviting a user through the SendGrid API, an email address is necessary. However, to retrieve user information, the username becomes essential.

The intention is to ensure uniqueness by obtaining the username from the email address when utilizing this library with terraform-provider.