### PR TITLE
Support api_keys API

### DIFF
--- a/api_key.go
+++ b/api_key.go
@@ -1,0 +1,142 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+)
+
+type APIKey struct {
+	ApiKeyId string `json:"api_key_id,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+type OutputGetAPIKeys struct {
+	APIKeys []APIKey `json:"result,omitempty"`
+}
+
+func (c *Client) GetAPIKeys(ctx context.Context) (*OutputGetAPIKeys, error) {
+	req, err := c.NewRequest("GET", "/api_keys", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetAPIKeys)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetAPIKey struct {
+	ApiKeyId string   `json:"api_key_id,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Scopes   []string `json:"scopes,omitempty"`
+}
+
+func (c *Client) GetAPIKey(ctx context.Context, apiKeyId string) (*OutputGetAPIKey, error) {
+	path := fmt.Sprintf("/api_keys/%s", apiKeyId)
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetAPIKey)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputCreateAPIKey struct {
+	Name   string   `json:"name,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+type OutputCreateAPIKey struct {
+	ApiKey   string   `json:"api_key,omitempty"`
+	ApiKeyId string   `json:"api_key_id,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Scopes   []string `json:"scopes,omitempty"`
+}
+
+func (c *Client) CreateAPIKey(ctx context.Context, input *InputCreateAPIKey) (*OutputCreateAPIKey, error) {
+	req, err := c.NewRequest("POST", "/api_keys", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputCreateAPIKey)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateAPIKeyName struct {
+	Name string `json:"name"`
+}
+
+type OutputUpdateAPIKeyName struct {
+	ApiKeyId string `json:"api_key_id,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+func (c *Client) UpdateAPIKeyName(ctx context.Context, apiKeyId string, input *InputUpdateAPIKeyName) (*OutputUpdateAPIKeyName, error) {
+	u := fmt.Sprintf("/api_keys/%s", apiKeyId)
+
+	req, err := c.NewRequest("PATCH", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateAPIKeyName)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateAPIKeyNameAndScopes struct {
+	Name   string   `json:"name"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+type OutputUpdateAPIKeyNameAndScopes struct {
+	ApiKeyId string   `json:"api_key_id,omitempty"`
+	Name     string   `json:"name"`
+	Scopes   []string `json:"scopes,omitempty"`
+}
+
+func (c *Client) UpdateAPIKeyNameAndScopes(ctx context.Context, apiKeyId string, input *InputUpdateAPIKeyNameAndScopes) (*OutputUpdateAPIKeyNameAndScopes, error) {
+	u := fmt.Sprintf("/api_keys/%s", apiKeyId)
+
+	req, err := c.NewRequest("PUT", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateAPIKeyNameAndScopes)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (c *Client) DeleteAPIKey(ctx context.Context, apiKeyId string) error {
+	u := fmt.Sprintf("/api_keys/%s", apiKeyId)
+
+	req, err := c.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/api_key_test.go
+++ b/api_key_test.go
@@ -1,0 +1,264 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestGetAPIKeys(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{"result":[{
+			"api_key_id": "abcdefghijklmnopqrstuv",
+			"name": "full-access"
+		  }]}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetAPIKeys(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetAPIKeys{
+		APIKeys: []APIKey{
+			{
+				ApiKeyId: "abcdefghijklmnopqrstuv",
+				Name:     "full-access",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetAPIKeys_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetAPIKeys(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetAPIKey(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys/dummy", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"scopes": [],
+			"api_key_id": "dummy",
+			"name": "full-accesses"
+		  }`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetAPIKey(context.TODO(), "dummy")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetAPIKey{
+		ApiKeyId: "dummy",
+		Scopes:   []string{},
+		Name:     "full-accesses",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetAPIKey_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys/dummy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetAPIKey(context.TODO(), "dummy")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateAPIKey(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"api_key": "SG.abcdefghi",
+			"api_key_id": "dummy",
+			"name": "dummy",
+			"scopes":[
+				"user.profile.read",
+				"user.profile.update"
+			]
+		  }`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.CreateAPIKey(context.TODO(), &InputCreateAPIKey{
+		Name: "dummy",
+		Scopes: []string{
+			"user.profile.read",
+			"user.profile.update",
+		},
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	want := &OutputCreateAPIKey{
+		ApiKey:   "SG.abcdefghi",
+		ApiKeyId: "dummy",
+		Name:     "dummy",
+		Scopes: []string{
+			"user.profile.read",
+			"user.profile.update",
+		},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateAPIKeyName(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys/dummy", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"api_key_id": "dummy",
+			"name": "full-accesses-dummy"
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateAPIKeyName(context.TODO(), "dummy", &InputUpdateAPIKeyName{
+		Name: "full-accesses-dummy",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	want := &OutputUpdateAPIKeyName{
+		ApiKeyId: "dummy",
+		Name:     "full-accesses-dummy",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateAPIKeyName_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys/dummy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateAPIKeyName(context.TODO(), "dummy", &InputUpdateAPIKeyName{
+		Name: "full-accesses-dummy",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateAPIKeyNameAndScopes(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys/dummy", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"scopes": [
+				"user.profile.read",
+				"user.profile.update"
+			],
+			"api_key_id": "dummy",
+			"name": "full-accesses-dummy"
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateAPIKeyNameAndScopes(context.TODO(), "dummy", &InputUpdateAPIKeyNameAndScopes{
+		Name: "full-accesses-dummy",
+		Scopes: []string{
+			"user.profile.read",
+			"user.profile.update",
+		},
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	want := &OutputUpdateAPIKeyNameAndScopes{
+		ApiKeyId: "dummy",
+		Name:     "full-accesses-dummy",
+		Scopes: []string{
+			"user.profile.read",
+			"user.profile.update",
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestDeleteAPIKey(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys/dummy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.DeleteAPIKey(context.TODO(), "dummy")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+}
+
+func TestDeleteAPIKey_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api_keys/dummy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.DeleteAPIKey(context.TODO(), "dummy")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}

--- a/examples/create_api_key/main.go
+++ b/examples/create_api_key/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	key, err := c.CreateAPIKey(context.TODO(), &sendgrid.InputCreateAPIKey{
+		Name: "dummy",
+		Scopes: []string{
+			"user.profile.read",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("api key: %#v\n", key)
+
+	return nil
+}

--- a/examples/delete_api_key/main.go
+++ b/examples/delete_api_key/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	err := c.DeleteAPIKey(context.TODO(), "dummy_api_key_id")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/examples/get_api_key/main.go
+++ b/examples/get_api_key/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	key, err := c.GetAPIKey(context.TODO(), "dummy_api_key_id")
+	if err != nil {
+		return err
+	}
+	log.Printf("api key: id: %s name: %s\n", key.ApiKeyId, key.Name)
+
+	return nil
+}

--- a/examples/get_api_keys/main.go
+++ b/examples/get_api_keys/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.GetAPIKeys(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	for _, key := range r.APIKeys {
+		log.Printf("api key: %#v\n", key)
+	}
+
+	return nil
+}

--- a/examples/update_api_key_name/main.go
+++ b/examples/update_api_key_name/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	key, err := c.UpdateAPIKeyName(context.TODO(), "dummy_api_key_id", &sendgrid.InputUpdateAPIKeyName{
+		Name: "dummy-rewrite-name",
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("api key: %#v\n", key)
+
+	return nil
+}

--- a/examples/update_api_key_name_and_scopes/main.go
+++ b/examples/update_api_key_name_and_scopes/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	key, err := c.UpdateAPIKeyNameAndScopes(context.TODO(), "dummy_api_key_id", &sendgrid.InputUpdateAPIKeyNameAndScopes{
+		Name: "dummy-rewrite-name",
+		Scopes: []string{
+			"user.profile.read",
+			"user.profile.update",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("api key: %#v\n", key)
+
+	return nil
+}


### PR DESCRIPTION
- `GET /v3/api_keys`: Retrieve all API Keys belonging to the authenticated user
- `GET /v3/api_keys/{api_key_id}`: Retrieve an existing API Key
- `POST /v3/api_keys`: Create API keys
- `PATCH /v3/api_keys/{api_key_id}`: Update API key name
- `PUT /v3/api_keys/{api_key_id}`: Update API key name and scopes
- `DELETE /v3/api_keys/{api_key_id}`: Delete API keys