### PR TITLE
remove password from response of subuser creation API

### DIFF
--- a/subuser.go
+++ b/subuser.go
@@ -84,7 +84,6 @@ type OutputCreateSubuser struct {
 	Email              string           `json:"email"`
 	SignupSessionToken string           `json:"signup_session_token"`
 	AuthorizationToken string           `json:"authorization_token"`
-	Password           string           `json:"password"`
 	CreditAllocation   CreditAllocation `json:"credit_allocation"`
 }
 


### PR DESCRIPTION
Remove the password from the response of the subuser creation API, as the response does not include the password.