### PR TITLE
Support Sender Authentication

### DIFF
--- a/examples/add_ip_to_authenticated_domain/main.go
+++ b/examples/add_ip_to_authenticated_domain/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.AddIPToAuthenticatedDomain(context.TODO(), 1234567, &sendgrid.InputAddIPToAuthenticatedDomain{
+		IP: "127.0.0.1",
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("domain: %#v\n", r)
+
+	return nil
+}

--- a/examples/associate_authenticated_domain_with_subuser/main.go
+++ b/examples/associate_authenticated_domain_with_subuser/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.AssociateAuthenticatedDomainWithSubuser(context.TODO(), 1234567, &sendgrid.InputAssociateAuthenticatedDomainWithSubuser{
+		Username: "dummy",
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("domain: %#v\n", r)
+
+	return nil
+}

--- a/examples/authenticate_domain/main.go
+++ b/examples/authenticate_domain/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.AuthenticateDomain(context.TODO(), &sendgrid.InputAuthenticateDomain{
+		Domain: "example.com",
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("domain: %#v\n", r)
+
+	return nil
+}

--- a/examples/disassociate_authenticated_domain_from_subuser/main.go
+++ b/examples/disassociate_authenticated_domain_from_subuser/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	err := c.DisassociateAuthenticatedDomainFromSubuser(context.TODO(), "dummy")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/examples/get_authenticated_domain/main.go
+++ b/examples/get_authenticated_domain/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.GetAuthenticatedDomain(context.TODO(), 1234567)
+	if err != nil {
+		return err
+	}
+	log.Printf("domain: %#v\n", r)
+
+	return nil
+}

--- a/examples/get_authenticated_domains/main.go
+++ b/examples/get_authenticated_domains/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	domains, err := c.GetAuthenticatedDomains(context.TODO(), &sendgrid.InputGetAuthenticatedDomains{
+		Limit: 1,
+	})
+	if err != nil {
+		return err
+	}
+	for _, v := range domains {
+		log.Printf("domain authentication: %#v\n", v)
+	}
+
+	return nil
+}

--- a/examples/get_default_authentication/main.go
+++ b/examples/get_default_authentication/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.GetDefaultAuthentication(context.TODO(), &sendgrid.InputGetDefaultAuthentication{})
+	if err != nil {
+		return err
+	}
+	log.Printf("domain: %#v\n", r)
+
+	return nil
+}

--- a/examples/remove_ip_from_authenticated_domain/main.go
+++ b/examples/remove_ip_from_authenticated_domain/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	err := c.RemoveIPFromAuthenticatedDomain(context.TODO(), 1234567, "127.0.0.1")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/examples/update_domain_authentication/main.go
+++ b/examples/update_domain_authentication/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.UpdateDomainAuthentication(context.TODO(), 1234567, &sendgrid.InputUpdateDomainAuthentication{
+		Default:   false,
+		CustomSpf: true,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%#v\n", r)
+
+	return nil
+}

--- a/examples/validate_domain_authentication/main.go
+++ b/examples/validate_domain_authentication/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.ValidateDomainAuthentication(context.TODO(), 1234567)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%#v\n", r)
+
+	return nil
+}

--- a/sender_authentication.go
+++ b/sender_authentication.go
@@ -1,0 +1,414 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type DomainAuthentication struct {
+	ID                      int64                         `json:"id,omitempty"`
+	UserID                  int64                         `json:"user_id,omitempty"`
+	Subdomain               string                        `json:"subdomain,omitempty"`
+	Domain                  string                        `json:"domain,omitempty"`
+	Username                string                        `json:"username,omitempty"`
+	IPs                     []string                      `json:"ips,omitempty"`
+	CustomSpf               bool                          `json:"custom_spf,omitempty"`
+	Default                 bool                          `json:"default,omitempty"`
+	Legacy                  bool                          `json:"legacy,omitempty"`
+	AutomaticSecurity       bool                          `json:"automatic_security,omitempty"`
+	Valid                   bool                          `json:"valid,omitempty"`
+	DNS                     DNS                           `json:"dns,omitempty"`
+	Subusers                []SubuserSenderAuthentication `json:"subusers,omitempty"`
+	LastValidationAttemptAt int64                         `json:"last_validation_attempt_at,omitempty"`
+}
+
+type DNS struct {
+	MailCname Record `json:"mail_cname,omitempty"`
+	Dkim1     Record `json:"dkim1,omitempty"`
+	Dkim2     Record `json:"dkim2,omitempty"`
+}
+
+type Record struct {
+	Valid bool   `json:"valid,omitempty"`
+	Type  string `json:"type,omitempty"`
+	Host  string `json:"host,omitempty"`
+	Data  string `json:"data,omitempty"`
+}
+
+type SubuserSenderAuthentication struct {
+	UserID   int64  `json:"user_id,omitempty"`
+	Username string `json:"username,omitempty"`
+}
+
+type InputGetAuthenticatedDomains struct {
+	Limit           int
+	Offset          int
+	ExcludeSubusers bool
+	Username        string
+	Domain          string
+}
+
+func (c *Client) GetAuthenticatedDomains(ctx context.Context, input *InputGetAuthenticatedDomains) ([]*DomainAuthentication, error) {
+	u, err := url.Parse("/whitelabel/domains")
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	if input.Limit > 0 {
+		q.Set("limit", strconv.Itoa(input.Limit))
+	}
+	if input.Offset > 0 {
+		q.Set("offset", strconv.Itoa(input.Offset))
+	}
+	if input.ExcludeSubusers {
+		q.Set("exclude_subusers", "true")
+	}
+	if input.Username != "" {
+		q.Set("username", input.Username)
+	}
+	if input.Domain != "" {
+		q.Set("domain", input.Domain)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := c.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := []*DomainAuthentication{}
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputGetDefaultAuthentication struct {
+	Domain string
+}
+
+type OutputGetDefaultAuthentication struct {
+	ID                      int64                         `json:"id,omitempty"`
+	UserID                  int64                         `json:"user_id,omitempty"`
+	Subdomain               string                        `json:"subdomain,omitempty"`
+	Domain                  string                        `json:"domain,omitempty"`
+	Username                string                        `json:"username,omitempty"`
+	IPs                     []string                      `json:"ips,omitempty"`
+	CustomSpf               bool                          `json:"custom_spf,omitempty"`
+	Default                 bool                          `json:"default,omitempty"`
+	Legacy                  bool                          `json:"legacy,omitempty"`
+	AutomaticSecurity       bool                          `json:"automatic_security,omitempty"`
+	Valid                   bool                          `json:"valid,omitempty"`
+	DNS                     DNS                           `json:"dns,omitempty"`
+	Subusers                []SubuserSenderAuthentication `json:"subusers,omitempty"`
+	LastValidationAttemptAt int64                         `json:"last_validation_attempt_at,omitempty"`
+}
+
+func (c *Client) GetDefaultAuthentication(ctx context.Context, input *InputGetDefaultAuthentication) (*OutputGetDefaultAuthentication, error) {
+	u, err := url.Parse("/whitelabel/domains/default")
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	if input.Domain != "" {
+		q.Set("domain", input.Domain)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := c.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetDefaultAuthentication)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetAuthenticatedDomain struct {
+	ID                int64    `json:"id,omitempty"`
+	UserID            int64    `json:"user_id,omitempty"`
+	Subdomain         string   `json:"subdomain,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Username          string   `json:"username,omitempty"`
+	IPs               []string `json:"ips,omitempty"`
+	CustomSpf         bool     `json:"custom_spf,omitempty"`
+	Default           bool     `json:"default,omitempty"`
+	Legacy            bool     `json:"legacy,omitempty"`
+	AutomaticSecurity bool     `json:"automatic_security,omitempty"`
+	Valid             bool     `json:"valid,omitempty"`
+	DNS               DNS      `json:"dns,omitempty"`
+}
+
+func (c *Client) GetAuthenticatedDomain(ctx context.Context, domainId int64) (*OutputGetAuthenticatedDomain, error) {
+	path := fmt.Sprintf("/whitelabel/domains/%s", strconv.FormatInt(domainId, 10))
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetAuthenticatedDomain)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputAuthenticateDomain struct {
+	Domain             string   `json:"domain,omitempty"`
+	Subdomain          string   `json:"subdomain,omitempty"`
+	Username           string   `json:"username,omitempty"`
+	IPs                []string `json:"ips,omitempty"`
+	CustomSpf          bool     `json:"custom_spf,omitempty"`
+	Default            bool     `json:"default,omitempty"`
+	AutomaticSecurity  bool     `json:"automatic_security,omitempty"`
+	CustomDkimSelector string   `json:"custom_dkim_selector,omitempty"`
+}
+
+type OutputAuthenticateDomain struct {
+	ID                int64    `json:"id,omitempty"`
+	UserID            int64    `json:"user_id,omitempty"`
+	Subdomain         string   `json:"subdomain,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
+	Username          string   `json:"username,omitempty"`
+	IPs               []string `json:"ips,omitempty"`
+	CustomSpf         bool     `json:"custom_spf,omitempty"`
+	Default           bool     `json:"default,omitempty"`
+	Legacy            bool     `json:"legacy,omitempty"`
+	AutomaticSecurity bool     `json:"automatic_security,omitempty"`
+	Valid             bool     `json:"valid,omitempty"`
+	DNS               DNS      `json:"dns,omitempty"`
+}
+
+func (c *Client) AuthenticateDomain(ctx context.Context, input *InputAuthenticateDomain) (*OutputAuthenticateDomain, error) {
+	req, err := c.NewRequest("POST", "/whitelabel/domains", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputAuthenticateDomain)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type InputAddIPToAuthenticatedDomain struct {
+	IP string `json:"ip,omitempty"`
+}
+
+type OutputAddIPToAuthenticatedDomain struct {
+	ID                      int64    `json:"id,omitempty"`
+	UserID                  int64    `json:"user_id,omitempty"`
+	Subdomain               string   `json:"subdomain,omitempty"`
+	Domain                  string   `json:"domain,omitempty"`
+	Username                string   `json:"username,omitempty"`
+	IPs                     []string `json:"ips,omitempty"`
+	CustomSpf               bool     `json:"custom_spf,omitempty"`
+	Default                 bool     `json:"default,omitempty"`
+	Legacy                  bool     `json:"legacy,omitempty"`
+	AutomaticSecurity       bool     `json:"automatic_security,omitempty"`
+	Valid                   bool     `json:"valid,omitempty"`
+	DNS                     DNS      `json:"dns,omitempty"`
+	LastValidationAttemptAt int64    `json:"last_validation_attempt_at,omitempty"`
+}
+
+// NOTE: The 'dns' key in the API response for adding an IP to the authenticated domain is different from what is documented.
+// see: https://docs.sendgrid.com/api-reference/domain-authentication/add-an-ip-to-an-authenticated-domain#responses
+func (c *Client) AddIPToAuthenticatedDomain(ctx context.Context, domainId int64, input *InputAddIPToAuthenticatedDomain) (*OutputAddIPToAuthenticatedDomain, error) {
+	path := fmt.Sprintf("/whitelabel/domains/%s/ips", strconv.FormatInt(domainId, 10))
+	req, err := c.NewRequest("POST", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputAddIPToAuthenticatedDomain)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// NOTE: The 'dns' key in the API response for removing an IP to the authenticated domain is different from what is documented.
+// see: https://docs.sendgrid.com/api-reference/domain-authentication/remove-an-ip-from-an-authenticated-domain#responses
+func (c *Client) RemoveIPFromAuthenticatedDomain(ctx context.Context, domainId int64, ip string) error {
+	path := fmt.Sprintf("/whitelabel/domains/%s/ips/%s", strconv.FormatInt(domainId, 10), ip)
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+type OutputValidateDomainAuthentication struct {
+	ID                int64             `json:"id,omitempty"`
+	Valid             bool              `json:"valid,omitempty"`
+	ValidationResults ValidationResults `json:"validation_results,omitempty"`
+}
+
+type ValidationResults struct {
+	MailCname ValidationResult `json:"mail_cname,omitempty"`
+	Dkim1     ValidationResult `json:"dkim1,omitempty"`
+	Dkim2     ValidationResult `json:"dkim2,omitempty"`
+	SPF       ValidationResult `json:"spf,omitempty"`
+}
+
+type ValidationResult struct {
+	Valid  bool   `json:"valid,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+func (c *Client) ValidateDomainAuthentication(ctx context.Context, domainId int64) (*OutputValidateDomainAuthentication, error) {
+	path := fmt.Sprintf("/whitelabel/domains/%s/validate", strconv.FormatInt(domainId, 10))
+	req, err := c.NewRequest("POST", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputValidateDomainAuthentication)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type InputUpdateDomainAuthentication struct {
+	Default   bool `json:"default,omitempty"`
+	CustomSpf bool `json:"custom_spf,omitempty"`
+}
+
+type OutputUpdateDomainAuthentication struct {
+	ID                      int64                         `json:"id,omitempty"`
+	UserID                  int64                         `json:"user_id,omitempty"`
+	Subdomain               string                        `json:"subdomain,omitempty"`
+	Domain                  string                        `json:"domain,omitempty"`
+	Username                string                        `json:"username,omitempty"`
+	IPs                     []string                      `json:"ips,omitempty"`
+	CustomSpf               bool                          `json:"custom_spf,omitempty"`
+	Default                 bool                          `json:"default,omitempty"`
+	Legacy                  bool                          `json:"legacy,omitempty"`
+	AutomaticSecurity       bool                          `json:"automatic_security,omitempty"`
+	Valid                   bool                          `json:"valid,omitempty"`
+	DNS                     DNS                           `json:"dns,omitempty"`
+	Subusers                []SubuserSenderAuthentication `json:"subusers,omitempty"`
+	LastValidationAttemptAt int64                         `json:"last_validation_attempt_at,omitempty"`
+}
+
+func (c *Client) UpdateDomainAuthentication(ctx context.Context, domainId int64, input *InputUpdateDomainAuthentication) (*OutputUpdateDomainAuthentication, error) {
+	path := fmt.Sprintf("/whitelabel/domains/%s", strconv.FormatInt(domainId, 10))
+	req, err := c.NewRequest("PATCH", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateDomainAuthentication)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (c *Client) DeleteAuthenticatedDomain(ctx context.Context, domainId int64) error {
+	path := fmt.Sprintf("/whitelabel/domains/%s", strconv.FormatInt(domainId, 10))
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+type OutputGetAuthenticatedDomainAssociatedWithSubuser struct {
+	ID                      int64    `json:"id,omitempty"`
+	UserID                  int64    `json:"user_id,omitempty"`
+	Subdomain               string   `json:"subdomain,omitempty"`
+	Domain                  string   `json:"domain,omitempty"`
+	Username                string   `json:"username,omitempty"`
+	IPs                     []string `json:"ips,omitempty"`
+	CustomSpf               bool     `json:"custom_spf,omitempty"`
+	Default                 bool     `json:"default,omitempty"`
+	Legacy                  bool     `json:"legacy,omitempty"`
+	AutomaticSecurity       bool     `json:"automatic_security,omitempty"`
+	Valid                   bool     `json:"valid,omitempty"`
+	DNS                     DNS      `json:"dns,omitempty"`
+	LastValidationAttemptAt int64    `json:"last_validation_attempt_at,omitempty"`
+}
+
+func (c *Client) GetAuthenticatedDomainAssociatedWithSubuser(ctx context.Context, subuserName string) (*OutputGetAuthenticatedDomainAssociatedWithSubuser, error) {
+	path := fmt.Sprintf("/whitelabel/domains/subuser?username=%s", subuserName)
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetAuthenticatedDomainAssociatedWithSubuser)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type InputAssociateAuthenticatedDomainWithSubuser struct {
+	Username string `json:"username,omitempty"`
+}
+
+type OutputAssociateAuthenticatedDomainWithSubuser struct {
+	ID                      int64    `json:"id,omitempty"`
+	UserID                  int64    `json:"user_id,omitempty"`
+	Subdomain               string   `json:"subdomain,omitempty"`
+	Domain                  string   `json:"domain,omitempty"`
+	Username                string   `json:"username,omitempty"`
+	IPs                     []string `json:"ips,omitempty"`
+	CustomSpf               bool     `json:"custom_spf,omitempty"`
+	Default                 bool     `json:"default,omitempty"`
+	Legacy                  bool     `json:"legacy,omitempty"`
+	AutomaticSecurity       bool     `json:"automatic_security,omitempty"`
+	Valid                   bool     `json:"valid,omitempty"`
+	DNS                     DNS      `json:"dns,omitempty"`
+	LastValidationAttemptAt int64    `json:"last_validation_attempt_at,omitempty"`
+}
+
+func (c *Client) AssociateAuthenticatedDomainWithSubuser(ctx context.Context, domainId int64, input *InputAssociateAuthenticatedDomainWithSubuser) (*OutputAssociateAuthenticatedDomainWithSubuser, error) {
+	path := fmt.Sprintf("/whitelabel/domains/%s/subuser", strconv.FormatInt(domainId, 10))
+	req, err := c.NewRequest("POST", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputAssociateAuthenticatedDomainWithSubuser)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (c *Client) DisassociateAuthenticatedDomainFromSubuser(ctx context.Context, subuserName string) error {
+	path := fmt.Sprintf("/whitelabel/domains/subuser?username=%s", subuserName)
+
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/sender_authentication_test.go
+++ b/sender_authentication_test.go
@@ -1,0 +1,1025 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestGetAuthenticatedDomains(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		q.Set("limit", "1")
+		q.Set("offset", "10")
+		q.Set("exclude_subusers", "true")
+		q.Set("username", "dummy")
+		q.Set("domain", "example.com")
+		r.URL.RawQuery = q.Encode()
+
+		if _, err := fmt.Fprint(w, `[
+			{
+				"id": 1234567,
+				"user_id": 9876543,
+				"subdomain": "em1234",
+				"domain": "example.com",
+				"username": "dummy",
+				"ips": [],
+				"custom_spf": false,
+				"default": false,
+				"legacy": false,
+				"automatic_security": true,
+				"valid": false,
+				"dns": {
+					"mail_cname": {
+						"valid": false,
+						"type": "cname",
+						"host": "em1234.example.com",
+						"data": "u1234567.wl123.sendgrid.net"
+					},
+					"dkim1": {
+						"valid": false,
+						"type":  "cname",
+						"host":  "s1._domainkey.example.com",
+						"data":  "s1.domainkey.u1234567.wl123.sendgrid.net"
+					},
+					"dkim2": {
+						"valid": false,
+						"type":  "cname",
+						"host":  "s2._domainkey.example.com",
+						"data":  "s2.domainkey.u1234567.wl123.sendgrid.net"
+					}
+				},
+				"last_validation_attempt_at": 1608242131
+			}
+		]`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetAuthenticatedDomains(context.TODO(), &InputGetAuthenticatedDomains{
+		Limit:           1,
+		Offset:          10,
+		ExcludeSubusers: true,
+		Username:        "dummy",
+		Domain:          "example.com",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*DomainAuthentication{
+		{
+			ID:                1234567,
+			UserID:            9876543,
+			Subdomain:         "em1234",
+			Domain:            "example.com",
+			Username:          "dummy",
+			IPs:               []string{},
+			CustomSpf:         false,
+			Default:           false,
+			Legacy:            false,
+			AutomaticSecurity: true,
+			Valid:             false,
+			DNS: DNS{
+				MailCname: Record{
+					Valid: false,
+					Type:  "cname",
+					Host:  "em1234.example.com",
+					Data:  "u1234567.wl123.sendgrid.net",
+				},
+				Dkim1: Record{
+					Valid: false,
+					Type:  "cname",
+					Host:  "s1._domainkey.example.com",
+					Data:  "s1.domainkey.u1234567.wl123.sendgrid.net",
+				},
+				Dkim2: Record{
+					Valid: false,
+					Type:  "cname",
+					Host:  "s2._domainkey.example.com",
+					Data:  "s2.domainkey.u1234567.wl123.sendgrid.net",
+				},
+			},
+			LastValidationAttemptAt: 1608242131,
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetAuthenticatedDomains_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetAuthenticatedDomains(context.TODO(), &InputGetAuthenticatedDomains{})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetDefaultAuthentication(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/default", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		q.Set("domain", "sendgrid.net")
+		r.URL.RawQuery = q.Encode()
+
+		if _, err := fmt.Fprint(w, `{
+			"id": 0,
+			"user_id": 0,
+			"subdomain": "",
+			"domain": "sendgrid.net",
+			"username": "",
+			"ips": null,
+			"custom_spf": false,
+			"default": false,
+			"legacy": false,
+			"automatic_security": false,
+			"valid": false,
+			"dns": {}
+		  }`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetDefaultAuthentication(context.TODO(), &InputGetDefaultAuthentication{
+		Domain: "sendgrid.net",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetDefaultAuthentication{
+		ID:                0,
+		UserID:            0,
+		Subdomain:         "",
+		Domain:            "sendgrid.net",
+		Username:          "",
+		IPs:               nil,
+		CustomSpf:         false,
+		Default:           false,
+		Legacy:            false,
+		AutomaticSecurity: false,
+		Valid:             false,
+		DNS: DNS{
+			MailCname: Record{
+				Valid: false,
+				Type:  "",
+				Host:  "",
+				Data:  "",
+			},
+			Dkim1: Record{
+				Valid: false,
+				Type:  "",
+				Host:  "",
+				Data:  "",
+			},
+			Dkim2: Record{
+				Valid: false,
+				Type:  "",
+				Host:  "",
+				Data:  "",
+			},
+		},
+		Subusers:                []SubuserSenderAuthentication(nil),
+		LastValidationAttemptAt: 0,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetDefaultAuthentication_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/default", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetDefaultAuthentication(context.TODO(), &InputGetDefaultAuthentication{})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetAuthenticatedDomain(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/1234567", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": 1234567,
+			"user_id": 9876543,
+			"subdomain": "em1234",
+			"domain": "example.com",
+			"username": "dummy",
+			"ips": [],
+			"custom_spf": false,
+			"default": false,
+			"legacy": false,
+			"automatic_security": true,
+			"valid": false,
+			"dns": {
+				"mail_cname": {
+					"valid": false,
+					"type": "cname",
+					"host": "em1234.example.com",
+					"data": "u1234567.wl123.sendgrid.net"
+				},
+				"dkim1": {
+					"valid": false,
+					"type":  "cname",
+					"host":  "s1._domainkey.example.com",
+					"data":  "s1.domainkey.u1234567.wl123.sendgrid.net"
+				},
+				"dkim2": {
+					"valid": false,
+					"type":  "cname",
+					"host":  "s2._domainkey.example.com",
+					"data":  "s2.domainkey.u1234567.wl123.sendgrid.net"
+				}
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetAuthenticatedDomain(context.TODO(), 1234567)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetAuthenticatedDomain{
+		ID:                1234567,
+		UserID:            9876543,
+		Subdomain:         "em1234",
+		Domain:            "example.com",
+		Username:          "dummy",
+		IPs:               []string{},
+		CustomSpf:         false,
+		Default:           false,
+		Legacy:            false,
+		AutomaticSecurity: true,
+		Valid:             false,
+		DNS: DNS{
+			MailCname: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "em1234.example.com",
+				Data:  "u1234567.wl123.sendgrid.net",
+			},
+			Dkim1: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s1._domainkey.example.com",
+				Data:  "s1.domainkey.u1234567.wl123.sendgrid.net",
+			},
+			Dkim2: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s2._domainkey.example.com",
+				Data:  "s2.domainkey.u1234567.wl123.sendgrid.net",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetAuthenticatedDomain_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/1234567", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetAuthenticatedDomain(context.TODO(), 1234567)
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestAuthenticatedDomain(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": 12345678,
+			"user_id": 9876543,
+			"subdomain": "em1234",
+			"domain": "example.com",
+			"username": "dummy",
+			"ips": [],
+			"custom_spf": false,
+			"default": false,
+			"legacy": false,
+			"automatic_security": true,
+			"valid": false,
+			"dns":{
+				"mail_cname": {
+					"valid": false,
+					"type": "cname",
+					"host": "em1234.example.com",
+					"data": "u1234567.wl123.sendgrid.net"
+				},
+				"dkim1":{
+					"valid": false,
+					"type": "cname",
+					"host": "s1._domainkey.example.com",
+					"data": "s1.domainkey.u1234567.wl123.sendgrid.net"
+				},
+				"dkim2":{
+					"valid": false,
+					"type": "cname",
+					"host": "s2._domainkey.example.com",
+					"data": "s2.domainkey.u1234567.wl123.sendgrid.net"
+				}
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.AuthenticateDomain(context.TODO(), &InputAuthenticateDomain{
+		Domain: "example.com",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputAuthenticateDomain{
+		ID:                12345678,
+		UserID:            9876543,
+		Subdomain:         "em1234",
+		Domain:            "example.com",
+		Username:          "dummy",
+		IPs:               []string{},
+		CustomSpf:         false,
+		Default:           false,
+		Legacy:            false,
+		AutomaticSecurity: true,
+		Valid:             false,
+		DNS: DNS{
+			MailCname: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "em1234.example.com",
+				Data:  "u1234567.wl123.sendgrid.net",
+			},
+			Dkim1: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s1._domainkey.example.com",
+				Data:  "s1.domainkey.u1234567.wl123.sendgrid.net",
+			},
+			Dkim2: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s2._domainkey.example.com",
+				Data:  "s2.domainkey.u1234567.wl123.sendgrid.net",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestAuthenticatedDomain_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.AuthenticateDomain(context.TODO(), &InputAuthenticateDomain{
+		Domain: "example.com",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestAddIPToAuthenticatedDomain(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678/ips", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": 12345678,
+			"user_id": 9876543,
+			"subdomain": "em1234",
+			"domain": "example.com",
+			"username": "dummy",
+			"ips": ["127.0.0.1"],
+			"custom_spf": false,
+			"default": false,
+			"legacy": false,
+			"automatic_security": true,
+			"valid": false,
+			"dns":{
+				"mail_cname": {
+					"valid": false,
+					"type": "cname",
+					"host": "em1234.example.com",
+					"data": "u1234567.wl123.sendgrid.net"
+				},
+				"dkim1":{
+					"valid": false,
+					"type": "cname",
+					"host": "s1._domainkey.example.com",
+					"data": "s1.domainkey.u1234567.wl123.sendgrid.net"
+				},
+				"dkim2":{
+					"valid": false,
+					"type": "cname",
+					"host": "s2._domainkey.example.com",
+					"data": "s2.domainkey.u1234567.wl123.sendgrid.net"
+				}
+			},
+			"last_validation_attempt_at": 1608242131
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.AddIPToAuthenticatedDomain(context.TODO(), 12345678, &InputAddIPToAuthenticatedDomain{
+		IP: "127.0.0.1",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputAddIPToAuthenticatedDomain{
+		ID:                12345678,
+		UserID:            9876543,
+		Subdomain:         "em1234",
+		Domain:            "example.com",
+		Username:          "dummy",
+		IPs:               []string{"127.0.0.1"},
+		CustomSpf:         false,
+		Default:           false,
+		Legacy:            false,
+		AutomaticSecurity: true,
+		Valid:             false,
+		DNS: DNS{
+			MailCname: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "em1234.example.com",
+				Data:  "u1234567.wl123.sendgrid.net",
+			},
+			Dkim1: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s1._domainkey.example.com",
+				Data:  "s1.domainkey.u1234567.wl123.sendgrid.net",
+			},
+			Dkim2: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s2._domainkey.example.com",
+				Data:  "s2.domainkey.u1234567.wl123.sendgrid.net",
+			},
+		},
+		LastValidationAttemptAt: 1608242131,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestAddIPToAuthenticatedDomain_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678/ips", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.AddIPToAuthenticatedDomain(context.TODO(), 12345678, &InputAddIPToAuthenticatedDomain{
+		IP: "127.0.0.1",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestRemoveIPFromAuthenticatedDomain(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678/ips/127.0.0.1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.RemoveIPFromAuthenticatedDomain(context.TODO(), 12345678, "127.0.0.1")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+}
+
+func TestRemoveIPFromAuthenticatedDomain_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678/ips/127.0.0.1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.RemoveIPFromAuthenticatedDomain(context.TODO(), 12345678, "127.0.0.1")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestValidateDomainAuthentication(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678/validate", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": 12345678,
+			"valid": false,
+			"validation_results": {
+				"mail_cname": {
+					"valid": false,
+					"reason": "Expected CNAME for \"em1234.example.com\" to match \"u1234567.wl123.sendgrid.net\"."
+				},
+				"dkim1": {
+					"valid": false,
+					"reason": "Expected CNAME for \"s1._domainkey.example.com\" to match \"s1.domainkey.u1234567.wl123.sendgrid.net\"."
+				},
+				"dkim2": {
+					"valid": false,
+					"reason": "Expected CNAME for \"s2._domainkey.ajinomoto.com\" to match \"s2.domainkey.u4707187.wl188.sendgrid.net\"."
+				},
+				"spf": {
+					"valid": false,
+					"reason": ""
+				}
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.ValidateDomainAuthentication(context.TODO(), 12345678)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputValidateDomainAuthentication{
+		ID:    12345678,
+		Valid: false,
+		ValidationResults: ValidationResults{
+			MailCname: ValidationResult{
+				Valid:  false,
+				Reason: "Expected CNAME for \"em1234.example.com\" to match \"u1234567.wl123.sendgrid.net\".",
+			},
+			Dkim1: ValidationResult{
+				Valid:  false,
+				Reason: "Expected CNAME for \"s1._domainkey.example.com\" to match \"s1.domainkey.u1234567.wl123.sendgrid.net\".",
+			},
+			Dkim2: ValidationResult{
+				Valid:  false,
+				Reason: "Expected CNAME for \"s2._domainkey.ajinomoto.com\" to match \"s2.domainkey.u4707187.wl188.sendgrid.net\".",
+			},
+			SPF: ValidationResult{
+				Valid:  false,
+				Reason: "",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestValidateDomainAuthentication_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678/validate", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.ValidateDomainAuthentication(context.TODO(), 12345678)
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateDomainAuthentication(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": 1234567,
+			"user_id": 9876543,
+			"subdomain": "em1234",
+			"domain": "example.com",
+			"username": "dummy",
+			"ips": [],
+			"custom_spf": false,
+			"default": false,
+			"legacy": false,
+			"automatic_security": true,
+			"valid": false,
+			"dns": {
+				"mail_cname": {
+					"valid": false,
+					"type": "cname",
+					"host": "em1234.example.com",
+					"data": "u1234567.wl123.sendgrid.net"
+				},
+				"dkim1": {
+					"valid": false,
+					"type":  "cname",
+					"host":  "s1._domainkey.example.com",
+					"data":  "s1.domainkey.u1234567.wl123.sendgrid.net"
+				},
+				"dkim2": {
+					"valid": false,
+					"type":  "cname",
+					"host":  "s2._domainkey.example.com",
+					"data":  "s2.domainkey.u1234567.wl123.sendgrid.net"
+				}
+			},
+			"last_validation_attempt_at": 1608242131
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateDomainAuthentication(context.TODO(), 12345678, &InputUpdateDomainAuthentication{
+		Default:   false,
+		CustomSpf: false,
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateDomainAuthentication{
+		ID:                1234567,
+		UserID:            9876543,
+		Subdomain:         "em1234",
+		Domain:            "example.com",
+		Username:          "dummy",
+		IPs:               []string{},
+		CustomSpf:         false,
+		Default:           false,
+		Legacy:            false,
+		AutomaticSecurity: true,
+		Valid:             false,
+		DNS: DNS{
+			MailCname: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "em1234.example.com",
+				Data:  "u1234567.wl123.sendgrid.net",
+			},
+			Dkim1: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s1._domainkey.example.com",
+				Data:  "s1.domainkey.u1234567.wl123.sendgrid.net",
+			},
+			Dkim2: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s2._domainkey.example.com",
+				Data:  "s2.domainkey.u1234567.wl123.sendgrid.net",
+			},
+		},
+		LastValidationAttemptAt: 1608242131,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateDomainAuthentication_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateDomainAuthentication(context.TODO(), 12345678, &InputUpdateDomainAuthentication{
+		Default:   false,
+		CustomSpf: false,
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteAuthenticatedDomain(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.DeleteAuthenticatedDomain(context.TODO(), 12345678)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+}
+
+func TestDeleteAuthenticatedDomain_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/12345678", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.DeleteAuthenticatedDomain(context.TODO(), 12345678)
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetAuthenticatedDomainAssociatedWithSubuser(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/subuser", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		q.Set("username", "dummy")
+		r.URL.RawQuery = q.Encode()
+
+		if _, err := fmt.Fprint(w, `{
+			"id": 1234567,
+			"user_id": 9876543,
+			"subdomain": "em1234",
+			"domain": "example.com",
+			"username": "dummy",
+			"ips": [],
+			"custom_spf": false,
+			"default": false,
+			"legacy": false,
+			"automatic_security": true,
+			"valid": false,
+			"dns": {
+				"mail_cname": {
+					"valid": false,
+					"type": "cname",
+					"host": "em1234.example.com",
+					"data": "u1234567.wl123.sendgrid.net"
+				},
+				"dkim1": {
+					"valid": false,
+					"type":  "cname",
+					"host":  "s1._domainkey.example.com",
+					"data":  "s1.domainkey.u1234567.wl123.sendgrid.net"
+				},
+				"dkim2": {
+					"valid": false,
+					"type":  "cname",
+					"host":  "s2._domainkey.example.com",
+					"data":  "s2.domainkey.u1234567.wl123.sendgrid.net"
+				}
+			},
+			"last_validation_attempt_at": 1608242131
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetAuthenticatedDomainAssociatedWithSubuser(context.TODO(), "dummy")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetAuthenticatedDomainAssociatedWithSubuser{
+		ID:                1234567,
+		UserID:            9876543,
+		Subdomain:         "em1234",
+		Domain:            "example.com",
+		Username:          "dummy",
+		IPs:               []string{},
+		CustomSpf:         false,
+		Default:           false,
+		Legacy:            false,
+		AutomaticSecurity: true,
+		Valid:             false,
+		DNS: DNS{
+			MailCname: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "em1234.example.com",
+				Data:  "u1234567.wl123.sendgrid.net",
+			},
+			Dkim1: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s1._domainkey.example.com",
+				Data:  "s1.domainkey.u1234567.wl123.sendgrid.net",
+			},
+			Dkim2: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s2._domainkey.example.com",
+				Data:  "s2.domainkey.u1234567.wl123.sendgrid.net",
+			},
+		},
+		LastValidationAttemptAt: 1608242131,
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetAuthenticatedDomainAssociatedWithSubuser_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/subuser?username=%s", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetAuthenticatedDomainAssociatedWithSubuser(context.TODO(), "")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestAssociateAuthenticatedDomainWithSubuser(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/1234567/subuser", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": 1234567,
+			"user_id": 9876543,
+			"subdomain": "em1234",
+			"domain": "example.com",
+			"username": "dummy",
+			"ips": [],
+			"custom_spf": false,
+			"default": false,
+			"legacy": false,
+			"automatic_security": true,
+			"valid": false,
+			"dns": {
+				"mail_cname": {
+					"valid": false,
+					"type": "cname",
+					"host": "em1234.example.com",
+					"data": "u1234567.wl123.sendgrid.net"
+				},
+				"dkim1": {
+					"valid": false,
+					"type":  "cname",
+					"host":  "s1._domainkey.example.com",
+					"data":  "s1.domainkey.u1234567.wl123.sendgrid.net"
+				},
+				"dkim2": {
+					"valid": false,
+					"type":  "cname",
+					"host":  "s2._domainkey.example.com",
+					"data":  "s2.domainkey.u1234567.wl123.sendgrid.net"
+				}
+			},
+			"last_validation_attempt_at": 1608242131
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.AssociateAuthenticatedDomainWithSubuser(context.TODO(), 1234567, &InputAssociateAuthenticatedDomainWithSubuser{
+		Username: "dummy",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputAssociateAuthenticatedDomainWithSubuser{
+		ID:                1234567,
+		UserID:            9876543,
+		Subdomain:         "em1234",
+		Domain:            "example.com",
+		Username:          "dummy",
+		IPs:               []string{},
+		CustomSpf:         false,
+		Default:           false,
+		Legacy:            false,
+		AutomaticSecurity: true,
+		Valid:             false,
+		DNS: DNS{
+			MailCname: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "em1234.example.com",
+				Data:  "u1234567.wl123.sendgrid.net",
+			},
+			Dkim1: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s1._domainkey.example.com",
+				Data:  "s1.domainkey.u1234567.wl123.sendgrid.net",
+			},
+			Dkim2: Record{
+				Valid: false,
+				Type:  "cname",
+				Host:  "s2._domainkey.example.com",
+				Data:  "s2.domainkey.u1234567.wl123.sendgrid.net",
+			},
+		},
+		LastValidationAttemptAt: 1608242131,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestAssociateAuthenticatedDomainWithSubuser_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/1234567/subuser", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.AssociateAuthenticatedDomainWithSubuser(context.TODO(), 1234567, &InputAssociateAuthenticatedDomainWithSubuser{
+		Username: "dummy",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDisassociateAuthenticatedDomainWithSubuser(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/subuser", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		q.Set("username", "dummy")
+		r.URL.RawQuery = q.Encode()
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.DisassociateAuthenticatedDomainFromSubuser(context.TODO(), "dummy")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+}
+
+func TestDisassociateAuthenticatedDomainWithSubuser_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/domains/subuser", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		q.Set("username", "dummy")
+		r.URL.RawQuery = q.Encode()
+
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.DisassociateAuthenticatedDomainFromSubuser(context.TODO(), "dummy")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}


### PR DESCRIPTION
- `POST /v3/whitelabel/domains`: Authenticate a domain
- `GET /v3/whitelabel/domains/default`: Get the default authentication
- `GET /v3/whitelabel/domains/{domain_id}`: Retrieve an authenticated domain
- `GET /v3/whitelabel/domains`: List all authenticated domains
- `POST /v3/whitelabel/domains/{id}/ips`: Add an IP to an authenticated domain
- `DELETE /v3/whitelabel/domains/{id}/ips/{ip}`: Remove an IP from an authenticated domain
- `POST /v3/whitelabel/domains/{id}/validate`: Validate a domain authentication
- `PATCH /v3/whitelabel/domains/{domain_id}`: Update an authenticated domain
- `DELETE /v3/whitelabel/domains/{domain_id}`: Delete an authenticated domain
- `GET /v3/whitelabel/domains/subuser`: List the authenticated domain associated with the given user
- `POST /v3/whitelabel/domains/{domain_id}/subuser`: Associate a authenticated domain with a given user
- `DELETE /v3/whitelabel/domains/subuser`: Disassociate a authenticated domain from a given user