### PR TITLE
fix: the error that cannot update to default = false with branded link update API

### DIFF
--- a/link_branding.go
+++ b/link_branding.go
@@ -229,7 +229,7 @@ func (c *Client) DisassociateBrandedLinkWithSubuser(ctx context.Context, usernam
 }
 
 type InputUpdateBrandedLink struct {
-	Default bool `json:"default,omitempty"`
+	Default bool `json:"default"`
 }
 
 type OutputUpdateBrandedLink struct {


### PR DESCRIPTION
json's omitempty option allows it to be omitted if false. API processing to update default to false was failing, so I removed the omitempty option.