### PR TITLE
Support Suppressions - Unsubscribe Groups API

### DIFF
--- a/examples/create_suppression_group/main.go
+++ b/examples/create_suppression_group/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.CreateSuppressionGroup(context.TODO(), &sendgrid.InputCreateSuppressionGroup{
+		Name:        "dummy",
+		Description: "dummy description",
+		IsDefault:   false,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("suppressionGroup: %#v", r)
+
+	return nil
+}

--- a/examples/delete_suppression_group/main.go
+++ b/examples/delete_suppression_group/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	err := c.DeleteSuppressionGroup(context.TODO(), 10000)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/examples/get_suppression_group/main.go
+++ b/examples/get_suppression_group/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	suppressionGroup, err := c.GetSuppressionGroup(context.TODO(), 10000)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("suppressionGroup: %#v", suppressionGroup)
+
+	return nil
+}

--- a/examples/get_suppression_groups/main.go
+++ b/examples/get_suppression_groups/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	suppressionGroups, err := c.GetSuppressionGroups(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	for _, suppressionGroup := range suppressionGroups {
+		log.Printf("suppressionGroup: %#v", suppressionGroup)
+	}
+
+	return nil
+}

--- a/examples/update_suppression_group/main.go
+++ b/examples/update_suppression_group/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.UpdateSuppressionGroup(context.TODO(), 10000, &sendgrid.InputUpdateSuppressionGroup{
+		Name:        "dummy 2",
+		Description: "dummy description 2",
+		IsDefault:   false,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("suppressionGroup: %#v", r)
+
+	return nil
+}

--- a/suppressions_unsubscribe_groups.go
+++ b/suppressions_unsubscribe_groups.go
@@ -1,0 +1,121 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+type SuppressionGroup struct {
+	ID              int64  `json:"id,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Description     string `json:"description,omitempty"`
+	IsDefault       bool   `json:"is_default,omitempty"`
+	Unsubscribes    int64  `json:"unsubscribes,omitempty"`
+	LastEmailSentAt string `json:"last_email_sent_at,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/suppressions-unsubscribe-groups/get-information-on-a-single-suppression-group
+func (c *Client) GetSuppressionGroup(ctx context.Context, id int64) (*SuppressionGroup, error) {
+	path := fmt.Sprintf("/asm/groups/%s", strconv.FormatInt(id, 10))
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(SuppressionGroup)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://docs.sendgrid.com/api-reference/suppressions-unsubscribe-groups/retrieve-all-suppression-groups-associated-with-the-user
+func (c *Client) GetSuppressionGroups(ctx context.Context) ([]*SuppressionGroup, error) {
+	req, err := c.NewRequest("GET", "/asm/groups", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := []*SuppressionGroup{}
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputCreateSuppressionGroup struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	IsDefault   bool   `json:"is_default,omitempty"`
+}
+
+type OutputCreateSuppressionGroup struct {
+	ID          int64  `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	IsDefault   bool   `json:"is_default,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/suppressions-unsubscribe-groups/create-a-new-suppression-group
+func (c *Client) CreateSuppressionGroup(ctx context.Context, input *InputCreateSuppressionGroup) (*OutputCreateSuppressionGroup, error) {
+	req, err := c.NewRequest("POST", "/asm/groups", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputCreateSuppressionGroup)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type InputUpdateSuppressionGroup struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	IsDefault   bool   `json:"is_default,omitempty"`
+}
+
+type OutputUpdateSuppressionGroup struct {
+	ID              int64  `json:"id,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Description     string `json:"description,omitempty"`
+	IsDefault       bool   `json:"is_default,omitempty"`
+	LastEmailSentAt string `json:"last_email_sent_at,omitempty"`
+	Unsubscribes    int64  `json:"unsubscribes,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/suppressions-unsubscribe-groups/update-a-suppression-group
+func (c *Client) UpdateSuppressionGroup(ctx context.Context, id int64, input *InputUpdateSuppressionGroup) (*OutputUpdateSuppressionGroup, error) {
+	path := fmt.Sprintf("/asm/groups/%s", strconv.FormatInt(id, 10))
+
+	req, err := c.NewRequest("PATCH", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateSuppressionGroup)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// see: https://docs.sendgrid.com/api-reference/suppressions-unsubscribe-groups/delete-a-suppression-group
+func (c *Client) DeleteSuppressionGroup(ctx context.Context, id int64) error {
+	path := fmt.Sprintf("/asm/groups/%s", strconv.FormatInt(id, 10))
+
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/suppressions_unsubscribe_groups_test.go
+++ b/suppressions_unsubscribe_groups_test.go
@@ -1,0 +1,249 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestGetSuppressionGroup(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups/12345", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id":12345,
+			"name":"dummy",
+			"description":"dummy description",
+			"is_default": false,
+			"unsubscribes": 0,
+			"last_email_sent_at": ""
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetSuppressionGroup(context.TODO(), 12345)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &SuppressionGroup{
+		ID:              12345,
+		Name:            "dummy",
+		Description:     "dummy description",
+		IsDefault:       false,
+		Unsubscribes:    0,
+		LastEmailSentAt: "",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetSuppressionGroup_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups/12345", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetSuppressionGroup(context.TODO(), 12345)
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetSuppressionGroups(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `[{
+			"id":12345,
+			"name":"dummy",
+			"description":"dummy description",
+			"is_default": false,
+			"unsubscribes": 0,
+			"last_email_sent_at": ""
+		}]`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetSuppressionGroups(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*SuppressionGroup{
+		{
+			ID:              12345,
+			Name:            "dummy",
+			Description:     "dummy description",
+			IsDefault:       false,
+			Unsubscribes:    0,
+			LastEmailSentAt: "",
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetSuppressionGroups_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetSuppressionGroups(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateSuppressionGroup(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id":12345,
+			"name":"dummy",
+			"description":"dummy description",
+			"is_default": false
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.CreateSuppressionGroup(context.TODO(), &InputCreateSuppressionGroup{
+		Name:        "dummy",
+		Description: "dummy description",
+		IsDefault:   false,
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputCreateSuppressionGroup{
+		ID:          12345,
+		Name:        "dummy",
+		Description: "dummy description",
+		IsDefault:   false,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestCreateSuppressionGroup_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.CreateSuppressionGroup(context.TODO(), &InputCreateSuppressionGroup{
+		Name:        "dummy",
+		Description: "dummy description",
+		IsDefault:   false,
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateSuppressionGroup(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups/12345", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id":12345,
+			"name":"dummy",
+			"description":"dummy description",
+			"is_default": false
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateSuppressionGroup(context.TODO(), 12345, &InputUpdateSuppressionGroup{
+		Name:        "dummy",
+		Description: "dummy description",
+		IsDefault:   false,
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateSuppressionGroup{
+		ID:              12345,
+		Name:            "dummy",
+		Description:     "dummy description",
+		IsDefault:       false,
+		LastEmailSentAt: "",
+		Unsubscribes:    0,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestUpdateSuppressionGroup_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateSuppressionGroup(context.TODO(), 12345, &InputUpdateSuppressionGroup{
+		Name:        "dummy",
+		Description: "dummy description",
+		IsDefault:   false,
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteSuppressionGroup(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups/12345", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := client.DeleteSuppressionGroup(context.TODO(), 12345); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+}
+
+func TestDeleteSuppressionGroup_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/asm/groups", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.DeleteSuppressionGroup(context.TODO(), 12345)
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}


### PR DESCRIPTION
- `POST /v3/asm/groups`: Create a new suppression group
- `GET /v3/asm/groups/{group_id}`: Get information on a single suppression group.
- `GET /v3/asm/groups`: Retrieve all suppression groups associated with the user.
- `PATCH /v3/asm/groups/{group_id}`: Update a suppression group.
- `DELETE /v3/asm/groups/{group_id}`: Delete a Suppression Group