### PR TITLE
support template & template version API

### DIFF
--- a/examples/activate_template_version/main.go
+++ b/examples/activate_template_version/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.ActivateTemplateVersion(context.TODO(), "d-abcde12345", "aaaaaa-bbbb-0000-0000-aaaaaaaaa")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("temlate version: %#v", r)
+
+	return nil
+}

--- a/examples/create_template/main.go
+++ b/examples/create_template/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.CreateTemplate(context.TODO(), &sendgrid.InputCreateTemplate{
+		Name:       "dummy",
+		Generation: "dynamic",
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("temlate: %#v", r)
+
+	return nil
+}

--- a/examples/create_template_version/main.go
+++ b/examples/create_template_version/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.CreateTemplateVersion(context.TODO(), "d-abcde12345", &sendgrid.InputCreateTemplateVersion{
+		Name:                 "dummy",
+		GeneratePlainContent: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("temlate: %#v", r)
+
+	return nil
+}

--- a/examples/delete_template/main.go
+++ b/examples/delete_template/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	err := c.DeleteTemplate(context.TODO(), "d-abcde12345")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/examples/delete_template_version/main.go
+++ b/examples/delete_template_version/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	err := c.DeleteTemplateVersion(context.TODO(), "d-12345abcde", "aaaaaa-bbbb-0000-0000-aaaaaaaaa")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/examples/duplicate_template/main.go
+++ b/examples/duplicate_template/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.DuplicateTemplate(context.TODO(), "d-12345abcde", &sendgrid.InputDuplicateTemplate{
+		Name: "dummy2",
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("temlate: %#v", r)
+
+	return nil
+}

--- a/examples/get_template/main.go
+++ b/examples/get_template/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	template, err := c.GetTemplate(context.TODO(), "d-12345abcde")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("template: %#v", template)
+
+	return nil
+}

--- a/examples/get_template_version/main.go
+++ b/examples/get_template_version/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	templateVersion, err := c.GetTemplateVersion(context.TODO(), "d-12345abcde", "aaaaaa-bbbb-0000-0000-aaaaaaaaa")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("template version: %#v", templateVersion)
+
+	return nil
+}

--- a/examples/get_templates/main.go
+++ b/examples/get_templates/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.GetTemplates(context.TODO(), &sendgrid.InputGetTemplates{
+		Generations: "dynamic",
+		PageSize:    10,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, u := range r.Templates {
+		log.Printf("template: %#v", u)
+	}
+
+	return nil
+}

--- a/examples/update_template/main.go
+++ b/examples/update_template/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.UpdateTemplate(context.TODO(), "d-abcde12345", &sendgrid.InputUpdateTemplate{
+		Name: "dummy",
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("template: %#v", r)
+
+	return nil
+}

--- a/examples/update_template_version/main.go
+++ b/examples/update_template_version/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.UpdateTemplateVersion(context.TODO(), "d-12345abcde", "aaaaaa-bbbb-0000-0000-aaaaaaaaa", &sendgrid.InputUpdateTemplateVersion{
+		Name:   "dummy",
+		Active: 0,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("template version: %#v", r)
+
+	return nil
+}

--- a/template.go
+++ b/template.go
@@ -1,0 +1,208 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type OutputGetTemplate struct {
+	ID         string    `json:"id,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	Generation string    `json:"generation,omitempty"`
+	UpdatedAt  string    `json:"updated_at,omitempty"`
+	Versions   []Version `json:"versions,omitempty"`
+	Warning    Warning   `json:"warning,omitempty"`
+}
+
+type Version struct {
+	ID                   string `json:"id,omitempty"`
+	TemplateID           string `json:"template_id,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Subject              string `json:"subject,omitempty"`
+	UpdatedAt            string `json:"updated_at,omitempty"`
+	GeneratePlainContent bool   `json:"generate_plain_content,omitempty"`
+	HTMLContent          string `json:"html_content,omitempty"`
+	PlainContent         string `json:"plain_content,omitempty"`
+	Editor               string `json:"editor,omitempty"`
+	ThumbnailURL         string `json:"thumbnail_url,omitempty"`
+}
+
+type Warning struct {
+	Message string `json:"message,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates/retrieve-a-single-transactional-template
+func (c *Client) GetTemplate(ctx context.Context, id string) (*OutputGetTemplate, error) {
+	path := fmt.Sprintf("/templates/%s", id)
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetTemplate)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputGetTemplates struct {
+	Generations string
+	PageSize    int
+	PageToken   string
+}
+
+type OutputGetTemplates struct {
+	Templates []Template `json:"result,omitempty"`
+	Metadata  Metadata   `json:"_metadata,omitempty"`
+}
+
+type Template struct {
+	ID         string    `json:"id,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	Generation string    `json:"generation,omitempty"`
+	UpdatedAt  string    `json:"updated_at,omitempty"`
+	Versions   []Version `json:"versions,omitempty"`
+}
+
+type Metadata struct {
+	Prev  string `json:"prev,omitempty"`
+	Self  string `json:"self,omitempty"`
+	Next  string `json:"next,omitempty"`
+	Count int    `json:"count,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates/retrieve-paged-transactional-templates
+func (c *Client) GetTemplates(ctx context.Context, input *InputGetTemplates) (*OutputGetTemplates, error) {
+	u, err := url.Parse("/templates")
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	if input.Generations != "" {
+		q.Set("generations", input.Generations)
+	}
+	if input.PageSize > 0 {
+		q.Set("page_size", strconv.Itoa(input.PageSize))
+	}
+	if input.PageToken != "" {
+		q.Set("page_token", input.PageToken)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := c.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetTemplates)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputCreateTemplate struct {
+	Name       string `json:"name,omitempty"`
+	Generation string `json:"generation,omitempty"`
+}
+
+type OutputCreateTemplate struct {
+	ID         string    `json:"id,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	Generation string    `json:"generation,omitempty"`
+	UpdatedAt  string    `json:"updated_at,omitempty"`
+	Versions   []Version `json:"versions,omitempty"`
+	Warning    Warning   `json:"warning,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates/create-a-transactional-template
+func (c *Client) CreateTemplate(ctx context.Context, input *InputCreateTemplate) (*OutputCreateTemplate, error) {
+	req, err := c.NewRequest("POST", "/templates", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputCreateTemplate)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type InputDuplicateTemplate struct {
+	Name string `json:"name,omitempty"`
+}
+
+type OutputDuplicateTemplate struct {
+	ID         string    `json:"id,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	Generation string    `json:"generation,omitempty"`
+	UpdatedAt  string    `json:"updated_at,omitempty"`
+	Versions   []Version `json:"versions,omitempty"`
+	Warning    Warning   `json:"warning,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates/duplicate-a-transactional-template
+func (c *Client) DuplicateTemplate(ctx context.Context, id string, input *InputDuplicateTemplate) (*OutputDuplicateTemplate, error) {
+	path := fmt.Sprintf("/templates/%s", id)
+	req, err := c.NewRequest("POST", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputDuplicateTemplate)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type InputUpdateTemplate struct {
+	Name string `json:"name,omitempty"`
+}
+
+type OutputUpdateTemplate struct {
+	ID         string    `json:"id,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	Generation string    `json:"generation,omitempty"`
+	UpdatedAt  string    `json:"updated_at,omitempty"`
+	Versions   []Version `json:"versions,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates/edit-a-transactional-template
+func (c *Client) UpdateTemplate(ctx context.Context, id string, input *InputUpdateTemplate) (*OutputUpdateTemplate, error) {
+	path := fmt.Sprintf("/templates/%s", id)
+
+	req, err := c.NewRequest("PATCH", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateTemplate)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates/delete-a-template
+func (c *Client) DeleteTemplate(ctx context.Context, id string) error {
+	path := fmt.Sprintf("/templates/%s", id)
+
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/template_test.go
+++ b/template_test.go
@@ -1,0 +1,392 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestGetTemplate(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id":"d-12345abcde",
+			"name":"dummy",
+			"generation":"dynamic",
+			"updated_at":"2020-10-14 02:24:21",
+			"versions": [{
+				"id": "6692fdc5-803f-45fe-8f07-a2c330f6f28b",
+				"template_id": "d-12345abcde",
+				"name": "dummy",
+				"subject": "dummy",
+				"updated_at": "2020-10-20 05:11:38",
+				"generate_plain_content": true,
+				"html_content": "<html>\n<head>\n  <title>dummy</title>\n</head>\n<body>\ndummy\n</body>\n</html>\n",
+				"plain_content": "",
+				"editor": "code",
+				"thumbnail_url": "//thumbnail-bucket.s3.amazonaws.com/dummy.png"
+			}]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetTemplate(context.TODO(), "d-12345abcde")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetTemplate{
+		ID:         "d-12345abcde",
+		Name:       "dummy",
+		Generation: "dynamic",
+		UpdatedAt:  "2020-10-14 02:24:21",
+		Versions: []Version{
+			{
+				ID:                   "6692fdc5-803f-45fe-8f07-a2c330f6f28b",
+				TemplateID:           "d-12345abcde",
+				Name:                 "dummy",
+				Subject:              "dummy",
+				UpdatedAt:            "2020-10-20 05:11:38",
+				GeneratePlainContent: true,
+				HTMLContent:          "<html>\n<head>\n  <title>dummy</title>\n</head>\n<body>\ndummy\n</body>\n</html>\n",
+				PlainContent:         "",
+				Editor:               "code",
+				ThumbnailURL:         "//thumbnail-bucket.s3.amazonaws.com/dummy.png",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetTemplate_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teammates/d-12345abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetTemplate(context.TODO(), "d-12345abcde")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetTemplates(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"result": [{
+				"id":"d-12345abcde",
+				"name":"dummy",
+				"generation":"dynamic",
+				"updated_at":"2020-10-14 02:24:21",
+				"versions": [{
+					"id": "6692fdc5-803f-45fe-8f07-a2c330f6f28b",
+					"template_id": "d-12345abcde",
+					"name": "dummy",
+					"subject": "dummy",
+					"updated_at": "2020-10-20 05:11:38",
+					"generate_plain_content": true,
+					"html_content": "<html>\n<head>\n  <title>dummy</title>\n</head>\n<body>\ndummy\n</body>\n</html>\n",
+					"plain_content": "",
+					"editor": "code",
+					"thumbnail_url": "//thumbnail-bucket.s3.amazonaws.com/dummy.png"
+				}]
+			}]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetTemplates(context.TODO(), &InputGetTemplates{
+		Generations: "dynamic",
+		PageSize:    1,
+		PageToken:   "dummy",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetTemplates{
+		Templates: []Template{
+			{
+				ID:         "d-12345abcde",
+				Name:       "dummy",
+				Generation: "dynamic",
+				UpdatedAt:  "2020-10-14 02:24:21",
+				Versions: []Version{
+					{
+						ID:                   "6692fdc5-803f-45fe-8f07-a2c330f6f28b",
+						TemplateID:           "d-12345abcde",
+						Name:                 "dummy",
+						Subject:              "dummy",
+						UpdatedAt:            "2020-10-20 05:11:38",
+						GeneratePlainContent: true,
+						HTMLContent:          "<html>\n<head>\n  <title>dummy</title>\n</head>\n<body>\ndummy\n</body>\n</html>\n",
+						PlainContent:         "",
+						Editor:               "code",
+						ThumbnailURL:         "//thumbnail-bucket.s3.amazonaws.com/dummy.png",
+					},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetTemplates_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetTemplates(context.TODO(), &InputGetTemplates{})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateTemplate(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id":"d-12345abcde",
+			"name":"dummy",
+			"generation":"dynamic",
+			"updated_at":"2020-10-14 02:24:21",
+			"versions": [{}]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.CreateTemplate(context.TODO(), &InputCreateTemplate{
+		Name:       "dummy",
+		Generation: "dynamic",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputCreateTemplate{
+		ID:         "d-12345abcde",
+		Name:       "dummy",
+		Generation: "dynamic",
+		UpdatedAt:  "2020-10-14 02:24:21",
+		Versions: []Version{
+			{
+				ID:                   "",
+				TemplateID:           "",
+				Name:                 "",
+				Subject:              "",
+				UpdatedAt:            "",
+				GeneratePlainContent: false,
+				HTMLContent:          "",
+				PlainContent:         "",
+				Editor:               "",
+				ThumbnailURL:         "",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestCreateTemplate_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.CreateTemplate(context.TODO(), &InputCreateTemplate{
+		Name:       "dummy",
+		Generation: "dynamic",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDuplicateTemplate(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id":"d-67890fghij",
+			"name":"dummy2",
+			"generation":"dynamic",
+			"updated_at":"2020-10-15 02:24:21",
+			"versions": [{}]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.DuplicateTemplate(context.TODO(), "d-12345abcde", &InputDuplicateTemplate{
+		Name: "dummy2",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputDuplicateTemplate{
+		ID:         "d-67890fghij",
+		Name:       "dummy2",
+		Generation: "dynamic",
+		UpdatedAt:  "2020-10-15 02:24:21",
+		Versions: []Version{
+			{
+				ID:                   "",
+				TemplateID:           "",
+				Name:                 "",
+				Subject:              "",
+				UpdatedAt:            "",
+				GeneratePlainContent: false,
+				HTMLContent:          "",
+				PlainContent:         "",
+				Editor:               "",
+				ThumbnailURL:         "",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestDuplicateTemplate_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.DuplicateTemplate(context.TODO(), "d-12345abcde", &InputDuplicateTemplate{
+		Name: "dummy",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateTemplate(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id":"d-12345abcde",
+			"name":"dummy2",
+			"generation":"dynamic",
+			"updated_at":"2020-10-14 02:24:21",
+			"versions": [{}]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateTemplate(context.TODO(), "d-12345abcde", &InputUpdateTemplate{
+		Name: "dummy2",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateTemplate{
+		ID:         "d-12345abcde",
+		Name:       "dummy2",
+		Generation: "dynamic",
+		UpdatedAt:  "2020-10-14 02:24:21",
+		Versions: []Version{
+			{
+				ID:                   "",
+				TemplateID:           "",
+				Name:                 "",
+				Subject:              "",
+				UpdatedAt:            "",
+				GeneratePlainContent: false,
+				HTMLContent:          "",
+				PlainContent:         "",
+				Editor:               "",
+				ThumbnailURL:         "",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateTemplate_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teammates/d-12345abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateTemplate(context.TODO(), "d-12345abcde", &InputUpdateTemplate{
+		Name: "dummy",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteTemplate(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.DeleteTemplate(context.TODO(), "d-12345abcde")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+}
+
+func TestDeleteTemplate_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/teammates/d-12345abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.DeleteTemplate(context.TODO(), "d-12345abcde")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}

--- a/template_version.go
+++ b/template_version.go
@@ -1,0 +1,174 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+)
+
+type OutputGetTemplateVersion struct {
+	ID                   string  `json:"id,omitempty"`
+	TemplateID           string  `json:"template_id,omitempty"`
+	Active               int     `json:"active,omitempty"`
+	Name                 string  `json:"name,omitempty"`
+	HTMLContent          string  `json:"html_content,omitempty"`
+	PlainContent         string  `json:"plain_content,omitempty"`
+	GeneratePlainContent bool    `json:"generate_plain_content,omitempty"`
+	Subject              string  `json:"subject,omitempty"`
+	Editor               string  `json:"editor,omitempty"`
+	TestData             string  `json:"test_data,omitempty"`
+	UpdatedAt            string  `json:"updated_at,omitempty"`
+	Warnings             Warning `json:"warnings,omitempty"`
+	ThumbnailURL         string  `json:"thumbnail_url,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates-versions/retrieve-a-specific-transactional-template-version
+func (c *Client) GetTemplateVersion(ctx context.Context, templateID, versionID string) (*OutputGetTemplateVersion, error) {
+	path := fmt.Sprintf("/templates/%s/versions/%s", templateID, versionID)
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetTemplateVersion)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputCreateTemplateVersion struct {
+	Active               int    `json:"active,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	HTMLContent          string `json:"html_content,omitempty"`
+	PlainContent         string `json:"plain_content,omitempty"`
+	GeneratePlainContent bool   `json:"generate_plain_content,omitempty"`
+	Subject              string `json:"subject,omitempty"`
+	Editor               string `json:"editor,omitempty"`
+	TestData             string `json:"test_data,omitempty"`
+}
+
+type OutputCreateTemplateVersion struct {
+	ID                   string    `json:"id,omitempty"`
+	TemplateID           string    `json:"template_id,omitempty"`
+	Active               int       `json:"active,omitempty"`
+	Name                 string    `json:"name,omitempty"`
+	HTMLContent          string    `json:"html_content,omitempty"`
+	PlainContent         string    `json:"plain_content,omitempty"`
+	GeneratePlainContent bool      `json:"generate_plain_content,omitempty"`
+	Subject              string    `json:"subject,omitempty"`
+	Editor               string    `json:"editor,omitempty"`
+	TestData             string    `json:"test_data,omitempty"`
+	UpdatedAt            string    `json:"updated_at,omitempty"`
+	Warnings             []Warning `json:"warnings,omitempty"`
+	ThumbnailURL         string    `json:"thumbnail_url,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates-versions/create-a-new-transactional-template-version
+func (c *Client) CreateTemplateVersion(ctx context.Context, templateID string, input *InputCreateTemplateVersion) (*OutputCreateTemplateVersion, error) {
+	path := fmt.Sprintf("/templates/%s/versions", templateID)
+	req, err := c.NewRequest("POST", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputCreateTemplateVersion)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type InputUpdateTemplateVersion struct {
+	Active               int    `json:"active,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	HTMLContent          string `json:"html_content,omitempty"`
+	PlainContent         string `json:"plain_content,omitempty"`
+	GeneratePlainContent bool   `json:"generate_plain_content,omitempty"`
+	Subject              string `json:"subject,omitempty"`
+	Editor               string `json:"editor,omitempty"`
+	TestData             string `json:"test_data,omitempty"`
+}
+
+type OutputUpdateTemplateVersion struct {
+	ID                   string    `json:"id,omitempty"`
+	TemplateID           string    `json:"template_id,omitempty"`
+	Active               int       `json:"active,omitempty"`
+	Name                 string    `json:"name,omitempty"`
+	HTMLContent          string    `json:"html_content,omitempty"`
+	PlainContent         string    `json:"plain_content,omitempty"`
+	GeneratePlainContent bool      `json:"generate_plain_content,omitempty"`
+	Subject              string    `json:"subject,omitempty"`
+	Editor               string    `json:"editor,omitempty"`
+	TestData             string    `json:"test_data,omitempty"`
+	UpdatedAt            string    `json:"updated_at,omitempty"`
+	Warnings             []Warning `json:"warnings,omitempty"`
+	ThumbnailURL         string    `json:"thumbnail_url,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates-versions/edit-a-transactional-template-version
+func (c *Client) UpdateTemplateVersion(ctx context.Context, templateID, versionID string, input *InputUpdateTemplateVersion) (*OutputUpdateTemplateVersion, error) {
+	path := fmt.Sprintf("/templates/%s/versions/%s", templateID, versionID)
+
+	req, err := c.NewRequest("PATCH", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateTemplateVersion)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputActivateTemplateVersion struct {
+	ID                   string    `json:"id,omitempty"`
+	TemplateID           string    `json:"template_id,omitempty"`
+	Active               int       `json:"active,omitempty"`
+	Name                 string    `json:"name,omitempty"`
+	HTMLContent          string    `json:"html_content,omitempty"`
+	PlainContent         string    `json:"plain_content,omitempty"`
+	GeneratePlainContent bool      `json:"generate_plain_content,omitempty"`
+	Subject              string    `json:"subject,omitempty"`
+	Editor               string    `json:"editor,omitempty"`
+	TestData             string    `json:"test_data,omitempty"`
+	UpdatedAt            string    `json:"updated_at,omitempty"`
+	Warnings             []Warning `json:"warnings,omitempty"`
+	ThumbnailURL         string    `json:"thumbnail_url,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates-versions/activate-a-transactional-template-version
+func (c *Client) ActivateTemplateVersion(ctx context.Context, templateID, versionID string) (*OutputActivateTemplateVersion, error) {
+	path := fmt.Sprintf("/templates/%s/versions/%s/activate", templateID, versionID)
+
+	req, err := c.NewRequest("POST", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputActivateTemplateVersion)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://docs.sendgrid.com/api-reference/transactional-templates-versions/delete-a-transactional-template-version
+func (c *Client) DeleteTemplateVersion(ctx context.Context, templateID, versionID string) error {
+	path := fmt.Sprintf("/templates/%s/versions/%s", templateID, versionID)
+
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/template_version_test.go
+++ b/template_version_test.go
@@ -1,0 +1,287 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestGetTemplateVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": "d-12345abcde",
+			"template_id": "abc1234-12ab-34cd-56ef-78901abcde",
+			"active": 1,
+			"name": "dummy",
+			"generate_plain_content": true,
+			"updated_at": "2024-01-20 08:46:07",
+			"editor": "code"
+		  }`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetTemplateVersion(context.TODO(), "d-12345abcde", "abc1234-12ab-34cd-56ef-78901abcde")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetTemplateVersion{
+		ID:                   "d-12345abcde",
+		TemplateID:           "abc1234-12ab-34cd-56ef-78901abcde",
+		Active:               1,
+		Name:                 "dummy",
+		GeneratePlainContent: true,
+		UpdatedAt:            "2024-01-20 08:46:07",
+		Editor:               "code",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetTemplateVersion_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetTemplateVersion(context.TODO(), "d-12345abcde", "abc1234-12ab-34cd-56ef-78901abcde")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateTemplateVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": "d-12345abcde",
+			"template_id": "abc1234-12ab-34cd-56ef-78901abcde",
+			"active": 0,
+			"name": "dummy",
+			"generate_plain_content": true,
+			"editor": "code",
+			"updated_at": "2024-01-20 08:46:07"
+		  }`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.CreateTemplateVersion(context.TODO(), "d-12345abcde", &InputCreateTemplateVersion{
+		Active:               0,
+		Name:                 "dummy",
+		GeneratePlainContent: true,
+		Editor:               "code",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputCreateTemplateVersion{
+		ID:                   "d-12345abcde",
+		TemplateID:           "abc1234-12ab-34cd-56ef-78901abcde",
+		Active:               0,
+		Name:                 "dummy",
+		HTMLContent:          "",
+		PlainContent:         "",
+		GeneratePlainContent: true,
+		Subject:              "",
+		Editor:               "code",
+		TestData:             "",
+		UpdatedAt:            "2024-01-20 08:46:07",
+		Warnings:             []Warning(nil),
+		ThumbnailURL:         "",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestCreateTemplateVersion_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.CreateTemplateVersion(context.TODO(), "d-12345abcde", &InputCreateTemplateVersion{
+		Active:               0,
+		Name:                 "dummy",
+		GeneratePlainContent: true,
+		Editor:               "code",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateTemplateVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": "abc1234-12ab-34cd-56ef-78901abcde",
+			"template_id": "d-12345abcde",
+			"active": 0,
+			"name": "dummy2",
+			"generate_plain_content": true,
+			"updated_at": "2024-01-20 15:46:46",
+			"editor": "code"
+		  }`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateTemplateVersion(context.TODO(), "d-12345abcde", "abc1234-12ab-34cd-56ef-78901abcde", &InputUpdateTemplateVersion{
+		Active:               0,
+		Name:                 "dummy2",
+		GeneratePlainContent: true,
+		Editor:               "code",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateTemplateVersion{
+		ID:                   "abc1234-12ab-34cd-56ef-78901abcde",
+		TemplateID:           "d-12345abcde",
+		Active:               0,
+		Name:                 "dummy2",
+		HTMLContent:          "",
+		PlainContent:         "",
+		GeneratePlainContent: true,
+		Subject:              "",
+		Editor:               "code",
+		TestData:             "",
+		UpdatedAt:            "2024-01-20 15:46:46",
+		Warnings:             []Warning(nil),
+		ThumbnailURL:         "",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateTemplateVersion_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateTemplateVersion(context.TODO(), "d-12345abcde", "abc1234-12ab-34cd-56ef-78901abcde", &InputUpdateTemplateVersion{
+		Active:               0,
+		Name:                 "dummy2",
+		GeneratePlainContent: true,
+		Editor:               "code",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestActivateTemplateVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde/activate", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": "abc1234-12ab-34cd-56ef-78901abcde",
+			"template_id": "d-12345abcde",
+			"active": 1,
+			"name": "dummy2",
+			"generate_plain_content": true,
+			"updated_at": "2024-01-20 15:46:46",
+			"editor": "code"
+		  }`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.ActivateTemplateVersion(context.TODO(), "d-12345abcde", "abc1234-12ab-34cd-56ef-78901abcde")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputActivateTemplateVersion{
+		ID:                   "abc1234-12ab-34cd-56ef-78901abcde",
+		TemplateID:           "d-12345abcde",
+		Active:               1,
+		Name:                 "dummy2",
+		HTMLContent:          "",
+		PlainContent:         "",
+		GeneratePlainContent: true,
+		Subject:              "",
+		Editor:               "code",
+		TestData:             "",
+		UpdatedAt:            "2024-01-20 15:46:46",
+		Warnings:             []Warning(nil),
+		ThumbnailURL:         "",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestActivateTemplateVersion_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.ActivateTemplateVersion(context.TODO(), "d-12345abcde", "abc1234-12ab-34cd-56ef-78901abcde")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteTemplateVersion(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.DeleteTemplateVersion(context.TODO(), "d-12345abcde", "abc1234-12ab-34cd-56ef-78901abcde")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+}
+
+func TestDeleteTemplateVersion_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/templates/d-12345abcde/versions/abc1234-12ab-34cd-56ef-78901abcde", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.DeleteTemplateVersion(context.TODO(), "d-12345abcde", "abc1234-12ab-34cd-56ef-78901abcde")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}


### PR DESCRIPTION
- template
  - `GET /v3/templates/{template_id}`: Retrieve a single transactional template.
  - `GET /v3/templates`: Retrieve paged transactional templates.
  - `POST /v3/templates`: Create a transactional template.
  - `POST /v3/templates/{template_id}`: Duplicate a transactional template.
  - `PATCH /v3/templates/{template_id}`: Edit a transactional template.
  - `DELETE /v3/templates/{template_id}`: Delete a template.
- template version
  - `GET /v3/templates/{template_id}/versions/{version_id}`: Retrieve a specific transactional template version.
  - `POST /v3/templates/{template_id}/versions`: Create a new transactional template version.
  - `POST /v3/templates/{template_id}/versions/{version_id}/activate`: Activate a transactional template version.
  - `PATCH /v3/templates/{template_id}/versions/{version_id}`: Edit a transactional template version.
  - `DELETE /v3/templates/{template_id}/versions/{version_id}`: Delete a transactional template version.