### PR TITLE
fix: {"error": "xxx"} format error

### DIFF
--- a/misc_test.go
+++ b/misc_test.go
@@ -13,6 +13,32 @@ func TestErrorResponse(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
+	mux.HandleFunc("/templates/d-12345abcde/versions/aaaaaa-bbbb-0000-0000-aaaaaaaaa", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		w.WriteHeader(http.StatusNotFound)
+		if _, err := fmt.Fprint(w, `{"error": "You cannot switch editors once a dynamic template version has been created."}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	client.debug = true
+	client.httpclient = &http.Client{}
+	client.log = log.New(os.Stdout, "sendgrid: ", log.Lshortfile|log.LstdFlags)
+
+	client.Debugf("%s", "test")
+	client.Debugln("test")
+
+	if _, err := client.UpdateTemplateVersion(context.TODO(), "d-12345abcde", "aaaaaa-bbbb-0000-0000-aaaaaaaaa", &InputUpdateTemplateVersion{
+		Editor: "code",
+	}); err == nil {
+		t.Fatal("expected an error but got none", err)
+	}
+}
+
+func TestErrorsResponse(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
 	mux.HandleFunc("/teammates/dummy", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
Return an error even in the case of an error response in the `{"error":"xxx"}` format.

https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/errors

The above link introduces the following formatting error, It turns out that there is indeed {"error": "error message"} .

```
{"errors": [{"field": "identifier1", "message": "error message explained"}]}
```