### PR TITLE
Support Reverse DNS API

### DIFF
--- a/examples/get_reverse_dnss/main.go
+++ b/examples/get_reverse_dnss/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.GetReverseDNSs(context.TODO(), &sendgrid.InputGetReverseDNSs{
+		Limit:  1,
+		Offset: 0,
+		IP:     "149.72.168.239",
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, d := range r {
+		log.Printf("%#v", d)
+	}
+
+	return nil
+}

--- a/reverse_dns.go
+++ b/reverse_dns.go
@@ -1,0 +1,168 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type InputGetReverseDNSs struct {
+	Limit  int    `json:"limit,omitempty"`
+	Offset int    `json:"offset,omitempty"`
+	IP     string `json:"ip,omitempty"`
+}
+
+type OutputGetReverseDNS struct {
+	ID                      int64   `json:"id,omitempty"`
+	IP                      string  `json:"ip,omitempty"`
+	RDNS                    string  `json:"rdns,omitempty"`
+	Users                   []*User `json:"users,omitempty"`
+	Subdomain               string  `json:"subdomain,omitempty"`
+	Domain                  string  `json:"domain,omitempty"`
+	Valid                   bool    `json:"valid,omitempty"`
+	Legacy                  bool    `json:"legacy,omitempty"`
+	LastValidationAttemptAt int64   `json:"last_validation_attempt_at,omitempty"`
+	ARecord                 ARecord `json:"a_record,omitempty"`
+}
+
+type User struct {
+	Username string `json:"username,omitempty"`
+	UserID   int64  `json:"user_id,omitempty"`
+}
+
+type ARecord struct {
+	Valid bool   `json:"valid,omitempty"`
+	Type  string `json:"type,omitempty"`
+	Host  string `json:"host,omitempty"`
+	Data  string `json:"data,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/reverse-dns/retrieve-all-reverse-dns-records
+func (c *Client) GetReverseDNSs(ctx context.Context, input *InputGetReverseDNSs) ([]*OutputGetReverseDNS, error) {
+	u, err := url.Parse("/whitelabel/ips")
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	if input.Limit > 0 {
+		q.Set("limit", strconv.Itoa(input.Limit))
+	}
+	if input.Offset > 0 {
+		q.Set("offset", strconv.Itoa(input.Offset))
+	}
+	if input.IP != "" {
+		q.Set("ip", input.IP)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := c.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := []*OutputGetReverseDNS{}
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://docs.sendgrid.com/api-reference/reverse-dns/retrieve-a-reverse-dns-record
+func (c *Client) GetReverseDNS(ctx context.Context, id int64) (*OutputGetReverseDNS, error) {
+	path := fmt.Sprintf("/whitelabel/ips/%v", id)
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetReverseDNS)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputCreateReverseDNS struct {
+	IP        string `json:"ip,omitempty"`
+	Subdomain string `json:"subdomain,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+}
+
+type OutputCreateReverseDNS struct {
+	ID                      int64   `json:"id,omitempty"`
+	IP                      string  `json:"ip,omitempty"`
+	RDNS                    string  `json:"rdns,omitempty"`
+	Users                   []*User `json:"users,omitempty"`
+	Subdomain               string  `json:"subdomain,omitempty"`
+	Domain                  string  `json:"domain,omitempty"`
+	Valid                   bool    `json:"valid,omitempty"`
+	Legacy                  bool    `json:"legacy,omitempty"`
+	LastValidationAttemptAt int64   `json:"last_validation_attempt_at,omitempty"`
+	ARecord                 ARecord `json:"a_record,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/reverse-dns/set-up-reverse-dns
+func (c *Client) CreateReverseDNS(ctx context.Context, input *InputCreateReverseDNS) (*OutputCreateReverseDNS, error) {
+	req, err := c.NewRequest("GET", "/whitelabel/ips", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputCreateReverseDNS)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputValidateReverseDNS struct {
+	ID                int64                       `json:"id,omitempty"`
+	Valid             bool                        `json:"valid,omitempty"`
+	ValidationResults ValidationResultsReverseDNS `json:"validation_results,omitempty"`
+}
+
+type ValidationResultsReverseDNS struct {
+	ARecordValidationResults ARecordValidationResults `json:"a_record,omitempty"`
+}
+
+type ARecordValidationResults struct {
+	Valid  bool   `json:"valid,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/reverse-dns/set-up-reverse-dns
+func (c *Client) ValidateReverseDNS(ctx context.Context, id int64) (*OutputValidateReverseDNS, error) {
+	path := fmt.Sprintf("/whitelabel/ips/%v/validate", id)
+	req, err := c.NewRequest("POST", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputValidateReverseDNS)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://docs.sendgrid.com/api-reference/reverse-dns/delete-a-reverse-dns-record
+func (c *Client) DeleteReverseDNS(ctx context.Context, id int64) error {
+	path := fmt.Sprintf("/whitelabel/ips/%v", id)
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/reverse_dns_test.go
+++ b/reverse_dns_test.go
@@ -1,0 +1,377 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestGetReverseDNSs(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		q.Set("limit", "1")
+		q.Set("offset", "10")
+		q.Set("ip", "150.150.150.150")
+		r.URL.RawQuery = q.Encode()
+
+		if _, err := fmt.Fprint(w, `[{
+			"id": 1234567,
+			"ip": "150.150.150.150",
+			"rdns": "o1.email.example.com",
+			"users": [
+				{
+					"user_id": 12345678,
+					"username": "dummy"
+				},
+				{
+					"user_id": 123456782,
+					"username": "dummy2"
+				}
+			],
+			"subdomain": "email",
+			"domain": "example.com",
+			"valid": true,
+			"legacy":false,
+			"last_validation_attempt_at":1575947780,
+			"a_record": {
+				"valid":true,
+				"type":"a",
+				"host":"o1.email.example.com",
+				"data":"150.150.150.150"
+			}
+		}]`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetReverseDNSs(context.TODO(), &InputGetReverseDNSs{
+		Limit:  1,
+		Offset: 10,
+		IP:     "150.150.150.150",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*OutputGetReverseDNS{
+		{
+			ID:   1234567,
+			IP:   "150.150.150.150",
+			RDNS: "o1.email.example.com",
+			Users: []*User{
+				{
+					UserID:   12345678,
+					Username: "dummy",
+				},
+				{
+					UserID:   123456782,
+					Username: "dummy2",
+				},
+			},
+			Subdomain:               "email",
+			Domain:                  "example.com",
+			Valid:                   true,
+			Legacy:                  false,
+			LastValidationAttemptAt: 1575947780,
+			ARecord: ARecord{
+				Valid: true,
+				Type:  "a",
+				Host:  "o1.email.example.com",
+				Data:  "150.150.150.150",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetReverseDNSs_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetReverseDNSs(context.TODO(), &InputGetReverseDNSs{
+		Limit:  1,
+		Offset: 10,
+		IP:     "150.150.150.150",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetReverseDNS(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips/1234567", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": 1234567,
+			"ip": "150.150.150.150",
+			"rdns": "o1.email.example.com",
+			"users": [
+				{
+					"user_id": 12345678,
+					"username": "dummy"
+				},
+				{
+					"user_id": 123456782,
+					"username": "dummy2"
+				}
+			],
+			"subdomain": "email",
+			"domain": "example.com",
+			"valid": true,
+			"legacy":false,
+			"last_validation_attempt_at":1575947780,
+			"a_record": {
+				"valid":true,
+				"type":"a",
+				"host":"o1.email.example.com",
+				"data":"150.150.150.150"
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetReverseDNS(context.TODO(), 1234567)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetReverseDNS{
+		ID:   1234567,
+		IP:   "150.150.150.150",
+		RDNS: "o1.email.example.com",
+		Users: []*User{
+			{
+				UserID:   12345678,
+				Username: "dummy",
+			},
+			{
+				UserID:   123456782,
+				Username: "dummy2",
+			},
+		},
+		Subdomain:               "email",
+		Domain:                  "example.com",
+		Valid:                   true,
+		Legacy:                  false,
+		LastValidationAttemptAt: 1575947780,
+		ARecord: ARecord{
+			Valid: true,
+			Type:  "a",
+			Host:  "o1.email.example.com",
+			Data:  "150.150.150.150",
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetReverseDNS_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips/1234567", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetReverseDNS(context.TODO(), 1234567)
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateReverseDNS(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": 1234567,
+			"ip": "150.150.150.150",
+			"rdns": "o1.email.example.com",
+			"users": [
+				{
+					"user_id": 12345678,
+					"username": "dummy"
+				},
+				{
+					"user_id": 123456782,
+					"username": "dummy2"
+				}
+			],
+			"subdomain": "email",
+			"domain": "example.com",
+			"valid": true,
+			"legacy":false,
+			"last_validation_attempt_at":1575947780,
+			"a_record": {
+				"valid":true,
+				"type":"a",
+				"host":"o1.email.example.com",
+				"data":"150.150.150.150"
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.CreateReverseDNS(context.TODO(), &InputCreateReverseDNS{
+		IP:        "150.150.150.150",
+		Subdomain: "email",
+		Domain:    "example.com",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputCreateReverseDNS{
+		ID:   1234567,
+		IP:   "150.150.150.150",
+		RDNS: "o1.email.example.com",
+		Users: []*User{
+			{
+				UserID:   12345678,
+				Username: "dummy",
+			},
+			{
+				UserID:   123456782,
+				Username: "dummy2",
+			},
+		},
+		Subdomain:               "email",
+		Domain:                  "example.com",
+		Valid:                   true,
+		Legacy:                  false,
+		LastValidationAttemptAt: 1575947780,
+		ARecord: ARecord{
+			Valid: true,
+			Type:  "a",
+			Host:  "o1.email.example.com",
+			Data:  "150.150.150.150",
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestCreateReverseDNS_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips/1234567", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.CreateReverseDNS(context.TODO(), &InputCreateReverseDNS{
+		IP:        "150.150.150.150",
+		Subdomain: "email",
+		Domain:    "example.com",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestValidateReverseDNS(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips/1234567/validate", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id":1234567,
+			"valid":true,
+			"validation_results":{
+				"a_record":{
+					"valid":true,
+					"reason":null
+				}
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.ValidateReverseDNS(context.TODO(), 1234567)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputValidateReverseDNS{
+		ID:    1234567,
+		Valid: true,
+		ValidationResults: ValidationResultsReverseDNS{
+			ARecordValidationResults: ARecordValidationResults{
+				Valid:  true,
+				Reason: "",
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestValidateReverseDNS_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips/1234567/validate", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.ValidateReverseDNS(context.TODO(), 1234567)
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteReverseDNS(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips/1234567", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.DeleteReverseDNS(context.TODO(), 1234567)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+}
+
+func TestDeleteReverseDNS_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/whitelabel/ips/1234567", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.DeleteReverseDNS(context.TODO(), 1234567)
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}


### PR DESCRIPTION
- `POST /v3/whitelabel/ips`: [Set up reverse DNS](https://docs.sendgrid.com/api-reference/reverse-dns/set-up-reverse-dns)
- `POST /v3/whitelabel/ips/{id}/validate`: [Validate a reverse DNS record](https://docs.sendgrid.com/api-reference/reverse-dns/validate-a-reverse-dns-record)
- `GET /v3/whitelabel/ips/{id}`: [Retrieve a reverse DNS record](https://docs.sendgrid.com/api-reference/reverse-dns/retrieve-a-reverse-dns-record)
- `GET /v3/whitelabel/ips`: [Retrieve all reverse DNS records](https://docs.sendgrid.com/api-reference/reverse-dns/retrieve-all-reverse-dns-records)
- `DELETE /v3/whitelabel/ips/{id}`: [Delete a reverse DNS record](https://docs.sendgrid.com/api-reference/reverse-dns/delete-a-reverse-dns-record)