### PR TITLE
Support Tracking API

### DIFF
--- a/examples/get_tracking_settings/main.go
+++ b/examples/get_tracking_settings/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.GetTrackingSettings(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	for _, d := range r.Result {
+		log.Printf("%#v", d)
+	}
+
+	return nil
+}

--- a/tracking.go
+++ b/tracking.go
@@ -1,0 +1,231 @@
+package sendgrid
+
+import (
+	"context"
+)
+
+type OutputGetTrackingSettings struct {
+	Result []*ResultGetTrackingSettings `json:"result,omitempty"`
+}
+
+type ResultGetTrackingSettings struct {
+	Name        string `json:"name,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/retrieve-tracking-settings
+func (c *Client) GetTrackingSettings(ctx context.Context) (*OutputGetTrackingSettings, error) {
+	req, err := c.NewRequest("GET", "/tracking_settings", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetTrackingSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetClickTrackingSettings struct {
+	EnableText bool `json:"enable_text,omitempty"`
+	Enabled    bool `json:"enabled,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/retrieve-click-track-settings
+func (c *Client) GetClickTrackingSettings(ctx context.Context) (*OutputGetClickTrackingSettings, error) {
+	req, err := c.NewRequest("GET", "/tracking_settings/click", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetClickTrackingSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateClickTrackingSettings struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+type OutputUpdateClickTrackingSettings struct {
+	EnableText bool `json:"enable_text,omitempty"`
+	Enabled    bool `json:"enabled,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/update-click-tracking-settings
+func (c *Client) UpdateClickTrackingSettings(ctx context.Context, input *InputUpdateClickTrackingSettings) (*OutputUpdateClickTrackingSettings, error) {
+	req, err := c.NewRequest("PATCH", "/tracking_settings/click", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateClickTrackingSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetOpenTrackingSettings struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/get-open-tracking-settings
+func (c *Client) GetOpenTrackingSettings(ctx context.Context) (*OutputGetOpenTrackingSettings, error) {
+	req, err := c.NewRequest("GET", "/tracking_settings/open", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetOpenTrackingSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateOpenTrackingSettings struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+type OutputUpdateOpenTrackingSettings struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/update-open-tracking-settings
+func (c *Client) UpdateOpenTrackingSettings(ctx context.Context, input *InputUpdateOpenTrackingSettings) (*OutputUpdateOpenTrackingSettings, error) {
+	req, err := c.NewRequest("PATCH", "/tracking_settings/open", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateOpenTrackingSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetGoogleAnalyticsSettings struct {
+	Enabled     bool   `json:"enabled,omitempty"`
+	UTMCampaign string `json:"utm_campaign,omitempty"`
+	UTMContent  string `json:"utm_content,omitempty"`
+	UTMMedium   string `json:"utm_medium,omitempty"`
+	UTMSource   string `json:"utm_source,omitempty"`
+	UTMTerm     string `json:"utm_term,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/retrieve-google-analytics-settings
+func (c *Client) GetGoogleAnalyticsSettings(ctx context.Context) (*OutputGetGoogleAnalyticsSettings, error) {
+	req, err := c.NewRequest("GET", "/tracking_settings/google_analytics", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetGoogleAnalyticsSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateGoogleAnalyticsSettings struct {
+	Enabled     bool   `json:"enabled,omitempty"`
+	UTMCampaign string `json:"utm_campaign,omitempty"`
+	UTMContent  string `json:"utm_content,omitempty"`
+	UTMMedium   string `json:"utm_medium,omitempty"`
+	UTMSource   string `json:"utm_source,omitempty"`
+	UTMTerm     string `json:"utm_term,omitempty"`
+}
+
+type OutputUpdateGoogleAnalyticsSettings struct {
+	Enabled     bool   `json:"enabled,omitempty"`
+	UTMCampaign string `json:"utm_campaign,omitempty"`
+	UTMContent  string `json:"utm_content,omitempty"`
+	UTMMedium   string `json:"utm_medium,omitempty"`
+	UTMSource   string `json:"utm_source,omitempty"`
+	UTMTerm     string `json:"utm_term,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/update-google-analytics-settings
+func (c *Client) UpdateGoogleAnalyticsSettings(ctx context.Context, input *InputUpdateGoogleAnalyticsSettings) (*OutputUpdateGoogleAnalyticsSettings, error) {
+	req, err := c.NewRequest("PATCH", "/tracking_settings/google_analytics", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateGoogleAnalyticsSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetSubscriptionTrackingSettings struct {
+	Enabled      bool   `json:"enabled,omitempty"`
+	HTMLContent  string `json:"html_content,omitempty"`
+	Landing      string `json:"landing,omitempty"`
+	PlainContent string `json:"plain_content,omitempty"`
+	Replace      string `json:"replace,omitempty"`
+	URL          string `json:"url,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/retrieve-subscription-tracking-settings
+func (c *Client) GetSubscriptionTrackingSettings(ctx context.Context) (*OutputGetSubscriptionTrackingSettings, error) {
+	req, err := c.NewRequest("GET", "/tracking_settings/subscription", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetSubscriptionTrackingSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateSubscriptionTrackingSettings struct {
+	Enabled      bool   `json:"enabled,omitempty"`
+	HTMLContent  string `json:"html_content,omitempty"`
+	Landing      string `json:"landing,omitempty"`
+	PlainContent string `json:"plain_content,omitempty"`
+	Replace      string `json:"replace,omitempty"`
+	URL          string `json:"url,omitempty"`
+}
+
+type OutputUpdateSubscriptionTrackingSettings struct {
+	Enabled      bool   `json:"enabled,omitempty"`
+	HTMLContent  string `json:"html_content,omitempty"`
+	Landing      string `json:"landing,omitempty"`
+	PlainContent string `json:"plain_content,omitempty"`
+	Replace      string `json:"replace,omitempty"`
+	URL          string `json:"url,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/settings-tracking/update-subscription-tracking-settings
+func (c *Client) UpdateSubscriptionTrackingSettings(ctx context.Context, input *InputUpdateSubscriptionTrackingSettings) (*OutputUpdateSubscriptionTrackingSettings, error) {
+	req, err := c.NewRequest("PATCH", "/tracking_settings/subscription", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateSubscriptionTrackingSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/tracking_test.go
+++ b/tracking_test.go
@@ -1,0 +1,492 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestGetTrackingSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"result":[
+				{
+					"title":"Click Tracking",
+					"enabled":false,
+					"name":"click",
+					"description":"Overwrites every link to track every click in emails."
+				},
+				{
+					"title":"Google Analytics",
+					"enabled":false,
+					"name":"google_analytics",
+					"description":"Track your conversion rates and ROI with Google Analytics."
+				},
+				{
+					"title":"Open Tracking",
+					"enabled":true,
+					"name":"open",
+					"description":"Appends an invisible image to HTML emails to track emails that have been opened."
+				},
+				{
+					"title":"Subscription Tracking",
+					"enabled":false,
+					"name":"subscription",
+					"description":"Adds unsubscribe links to the bottom of the text and HTML emails.  Future emails won't be delivered to unsubscribed users."
+				}
+			]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetTrackingSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetTrackingSettings{
+		Result: []*ResultGetTrackingSettings{
+			{
+				Name:        "click",
+				Title:       "Click Tracking",
+				Description: "Overwrites every link to track every click in emails.",
+				Enabled:     false,
+			},
+			{
+				Name:        "google_analytics",
+				Title:       "Google Analytics",
+				Description: "Track your conversion rates and ROI with Google Analytics.",
+				Enabled:     false,
+			},
+			{
+				Name:        "open",
+				Title:       "Open Tracking",
+				Description: "Appends an invisible image to HTML emails to track emails that have been opened.",
+				Enabled:     true,
+			},
+			{
+				Name:        "subscription",
+				Title:       "Subscription Tracking",
+				Description: "Adds unsubscribe links to the bottom of the text and HTML emails.  Future emails won't be delivered to unsubscribed users.",
+				Enabled:     false,
+			},
+		},
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetTrackingSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetTrackingSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetClickTrackingSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/click", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"enabled":true,
+			"enable_text":true
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetClickTrackingSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetClickTrackingSettings{
+		EnableText: true,
+		Enabled:    true,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetClickTrackingSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/click", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetClickTrackingSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateClickTrackingSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/click", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"enabled":true,
+			"enable_text":true
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateClickTrackingSettings(context.TODO(), &InputUpdateClickTrackingSettings{
+		Enabled: true,
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateClickTrackingSettings{
+		EnableText: true,
+		Enabled:    true,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateClickTrackingSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/click", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateClickTrackingSettings(context.TODO(), &InputUpdateClickTrackingSettings{
+		Enabled: true,
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetOpenTrackingSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/open", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"enabled":true
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetOpenTrackingSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetOpenTrackingSettings{
+		Enabled: true,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetOpenTrackingSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/open", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetOpenTrackingSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateOpenTrackingSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/open", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"enabled":true
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateOpenTrackingSettings(context.TODO(), &InputUpdateOpenTrackingSettings{
+		Enabled: true,
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateOpenTrackingSettings{
+		Enabled: true,
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateOpenTrackingSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/open", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateOpenTrackingSettings(context.TODO(), &InputUpdateOpenTrackingSettings{
+		Enabled: true,
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetGoogleAnalyticsSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/google_analytics", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"enabled":true,
+			"utm_source":"sendgrid.com",
+			"utm_medium":"email",
+			"utm_term":"",
+			"utm_content":"",
+			"utm_campaign":"sendgrid-email"
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetGoogleAnalyticsSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetGoogleAnalyticsSettings{
+		Enabled:     true,
+		UTMSource:   "sendgrid.com",
+		UTMMedium:   "email",
+		UTMTerm:     "",
+		UTMContent:  "",
+		UTMCampaign: "sendgrid-email",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetGoogleAnalyticsSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/google_analytics", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetGoogleAnalyticsSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateGoogleAnalyticsSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/google_analytics", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"enabled":true,
+			"utm_source":"sendgrid.com",
+			"utm_medium":"email",
+			"utm_term":"",
+			"utm_content":"",
+			"utm_campaign":"sendgrid-email"
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateGoogleAnalyticsSettings(context.TODO(), &InputUpdateGoogleAnalyticsSettings{
+		Enabled:     true,
+		UTMSource:   "sendgrid.com",
+		UTMMedium:   "email",
+		UTMTerm:     "",
+		UTMContent:  "",
+		UTMCampaign: "sendgrid-email",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateGoogleAnalyticsSettings{
+		Enabled:     true,
+		UTMSource:   "sendgrid.com",
+		UTMMedium:   "email",
+		UTMTerm:     "",
+		UTMContent:  "",
+		UTMCampaign: "sendgrid-email",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateGoogleAnalyticsSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/google_analytics", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateGoogleAnalyticsSettings(context.TODO(), &InputUpdateGoogleAnalyticsSettings{
+		Enabled:     true,
+		UTMSource:   "sendgrid.com",
+		UTMMedium:   "email",
+		UTMTerm:     "",
+		UTMContent:  "",
+		UTMCampaign: "sendgrid-email",
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetSubscriptionTrackingSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/subscription", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"enabled":false,
+			"html_content":"",
+			"landing":"",
+			"plain_content":"",
+			"replace":"",
+			"url":null
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetSubscriptionTrackingSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetSubscriptionTrackingSettings{
+		Enabled:      false,
+		HTMLContent:  "",
+		Landing:      "",
+		PlainContent: "",
+		Replace:      "",
+		URL:          "",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetSubscriptionTrackingSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/subscription", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetSubscriptionTrackingSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateSubscriptionTrackingSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/subscription", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"enabled":false,
+			"html_content":"",
+			"landing":"",
+			"plain_content":"",
+			"replace":"",
+			"url":null
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateSubscriptionTrackingSettings(context.TODO(), &InputUpdateSubscriptionTrackingSettings{
+		Enabled: false,
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateSubscriptionTrackingSettings{
+		Enabled:      false,
+		HTMLContent:  "",
+		Landing:      "",
+		PlainContent: "",
+		Replace:      "",
+		URL:          "",
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateSubscriptionTrackingSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/tracking_settings/subscription", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateSubscriptionTrackingSettings(context.TODO(), &InputUpdateSubscriptionTrackingSettings{
+		Enabled: false,
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}


### PR DESCRIPTION
- `GET /v3/tracking_settings`: [Retrieve Tracking Settings](https://docs.sendgrid.com/api-reference/settings-tracking/retrieve-tracking-settings)
- `GET /v3/tracking_settings/click`: [Retrieve Click Track Settings](https://docs.sendgrid.com/api-reference/settings-tracking/retrieve-click-track-settings)
- `PATCH /v3/tracking_settings/click`: [Update Click Tracking Settings](https://docs.sendgrid.com/api-reference/settings-tracking/update-click-tracking-settings)
- `GET /v3/tracking_settings/google_analytics`: [Retrieve Google Analytics Settings](https://docs.sendgrid.com/api-reference/settings-tracking/retrieve-google-analytics-settings)
- `PATCH /v3/tracking_settings/google_analytics`: [Update Google Analytics Settings](https://docs.sendgrid.com/api-reference/settings-tracking/update-google-analytics-settings)
- `GET /v3/tracking_settings/open`: [Get Open Tracking Settings](https://docs.sendgrid.com/api-reference/settings-tracking/get-open-tracking-settings)
- `PATCH /v3/tracking_settings/open`: [Update Open Tracking Settings](https://docs.sendgrid.com/api-reference/settings-tracking/update-open-tracking-settings)
- `GET /v3/tracking_settings/subscription`: [Retrieve Subscription Tracking Settings](https://docs.sendgrid.com/api-reference/settings-tracking/retrieve-subscription-tracking-settings)
- `PATCH /v3/tracking_settings/subscription`: [Update Subscription Tracking Settings](https://docs.sendgrid.com/api-reference/settings-tracking/update-subscription-tracking-settings)