### PR TITLE
Rate Limit エラー発生時に再実行する

### DIFF
--- a/sendgrid.go
+++ b/sendgrid.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/google/go-querystring/query"
 	"github.com/pkg/errors"
@@ -26,12 +27,13 @@ type httpClient interface {
 
 // Client : sendgrid client
 type Client struct {
-	apiKey     string
-	baseURL    *url.URL
-	debug      bool
-	log        ilogger
-	httpclient httpClient
-	subuser    string
+	apiKey        string
+	baseURL       *url.URL
+	debug         bool
+	log           ilogger
+	httpclient    httpClient
+	subuser       string
+	maxRetryCount int
 }
 
 // Option defines an option for a Client
@@ -73,13 +75,22 @@ func OptionLog(l logger) func(*Client) {
 	}
 }
 
+func OptionMaxRetryCount(maxRetryCount int) func(*Client) {
+	return func(c *Client) {
+		c.maxRetryCount = maxRetryCount
+	}
+}
+
+const defaultMaxRetryCount = 3
+
 // New builds a sendgrid client from the provided token, baseURL and options
 func New(apiKey string, options ...Option) *Client {
 	s := &Client{
-		apiKey:     apiKey,
-		baseURL:    defaultBaseURL,
-		httpclient: &http.Client{},
-		log:        log.New(os.Stderr, "kenzo0107/sendgrid", log.LstdFlags|log.Lshortfile),
+		apiKey:        apiKey,
+		baseURL:       defaultBaseURL,
+		httpclient:    &http.Client{},
+		log:           log.New(os.Stderr, "kenzo0107/sendgrid", log.LstdFlags|log.Lshortfile),
+		maxRetryCount: defaultMaxRetryCount,
 	}
 
 	for _, opt := range options {
@@ -173,7 +184,28 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 //
 // The provided ctx must be non-nil, if it is nil an error is returned. If it is canceled or times out,
 // ctx.Err() will be returned.
-func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) error {
+func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (err error) {
+	for retries := 0; retries < c.maxRetryCount; retries++ {
+		err = c.doRequest(ctx, req, v)
+		if err == nil {
+			break
+		}
+
+		// NOTE: when rate limit error occurs, wait until reset time and execute again
+		if rateLimitedError, ok := err.(*RateLimitedError); ok {
+			c.Debugln("rate limited error occurred", err)
+			select {
+			case <-ctx.Done():
+				err = ctx.Err()
+			case <-time.After(rateLimitedError.RetryAfter):
+				err = nil
+			}
+		}
+	}
+	return err
+}
+
+func (c *Client) doRequest(ctx context.Context, req *http.Request, v interface{}) error {
 	if ctx == nil {
 		return errors.New("context must be non-nil")
 	}

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -48,6 +48,7 @@ func setupWithPath() (client *Client, mux *http.ServeMux, serverURL string, tear
 		OptionHTTPClient(&http.Client{}),
 		OptionDebug(false),
 		OptionLog(log.New(os.Stderr, "kenzo0107/sendgrid", log.LstdFlags|log.Lshortfile)),
+		OptionMaxRetryCount(5),
 	)
 
 	return client, mux, server.URL, server.Close


### PR DESCRIPTION
現状 Rate Limit エラー発生時は異常終了しているが、
再試行する様にし、リトライし正常終了できる様にします。

最大リトライ数はデフォルトで 3 とし、外部から指定できる様にしています。