### PR TITLE
Disable execution processing when rate limit occurs

### DIFF
--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -48,7 +48,6 @@ func setupWithPath() (client *Client, mux *http.ServeMux, serverURL string, tear
 		OptionHTTPClient(&http.Client{}),
 		OptionDebug(false),
 		OptionLog(log.New(os.Stderr, "kenzo0107/sendgrid", log.LstdFlags|log.Lshortfile)),
-		OptionMaxRetryCount(5),
 	)
 
 	return client, mux, server.URL, server.Close


### PR DESCRIPTION
The purpose of re-execution processing is to make it easier for the user to handle it.