### PR TITLE
Support Event Webhook API

### DIFF
--- a/event_webhook.go
+++ b/event_webhook.go
@@ -1,0 +1,216 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+)
+
+type OutputGetEventWebhook struct {
+	ID               string `json:"id,omitempty"`
+	Enabled          bool   `json:"enabled,omitempty"`
+	URL              string `json:"url,omitempty"`
+	GroupResubscribe bool   `json:"group_resubscribe,omitempty"`
+	Delivered        bool   `json:"delivered,omitempty"`
+	GroupUnsubscribe bool   `json:"group_unsubscribe,omitempty"`
+	SpamReport       bool   `json:"spam_report,omitempty"`
+	Bounce           bool   `json:"bounce,omitempty"`
+	Deferred         bool   `json:"deferred,omitempty"`
+	Unsubscribe      bool   `json:"unsubscribe,omitempty"`
+	Processed        bool   `json:"processed,omitempty"`
+	Open             bool   `json:"open,omitempty"`
+	Click            bool   `json:"click,omitempty"`
+	Dropped          bool   `json:"dropped,omitempty"`
+	FriendlyName     string `json:"friendly_name,omitempty"`
+	OAuthClientID    string `json:"oauth_client_id,omitempty"`
+	OAuthTokenURL    string `json:"oauth_token_url,omitempty"`
+	PublicKey        string `json:"public_key,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/webhooks/get-an-event-webhook
+func (c *Client) GetEventWebhook(ctx context.Context, id string) (*OutputGetEventWebhook, error) {
+	path := fmt.Sprintf("/user/webhooks/event/settings/%s", id)
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetEventWebhook)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type EventWebhook struct {
+	ID               string `json:"id,omitempty"`
+	Enabled          bool   `json:"enabled,omitempty"`
+	URL              string `json:"url,omitempty"`
+	GroupResubscribe bool   `json:"group_resubscribe,omitempty"`
+	Delivered        bool   `json:"delivered,omitempty"`
+	GroupUnsubscribe bool   `json:"group_unsubscribe,omitempty"`
+	SpamReport       bool   `json:"spam_report,omitempty"`
+	Bounce           bool   `json:"bounce,omitempty"`
+	Deferred         bool   `json:"deferred,omitempty"`
+	Unsubscribe      bool   `json:"unsubscribe,omitempty"`
+	Processed        bool   `json:"processed,omitempty"`
+	Open             bool   `json:"open,omitempty"`
+	Click            bool   `json:"click,omitempty"`
+	Dropped          bool   `json:"dropped,omitempty"`
+	FriendlyName     string `json:"friendly_name,omitempty"`
+	OAuthClientID    string `json:"oauth_client_id,omitempty"`
+	OAuthTokenURL    string `json:"oauth_token_url,omitempty"`
+	PublicKey        string `json:"public_key,omitempty"`
+}
+
+type OutputGetEventWebhooks struct {
+	MaxAllowed int             `json:"max_allowed,omitempty"`
+	Webhooks   []*EventWebhook `json:"webhooks,omitempty"`
+}
+
+// https://docs.sendgrid.com/api-reference/webhooks/get-all-event-webhooks
+func (c *Client) GetEventWebhooks(ctx context.Context) (*OutputGetEventWebhooks, error) {
+	req, err := c.NewRequest("GET", "/user/webhooks/event/settings/all", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetEventWebhooks)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputCreateEventWebhook struct {
+	Enabled           bool   `json:"enabled,omitempty"`
+	URL               string `json:"url,omitempty"`
+	GroupResubscribe  bool   `json:"group_resubscribe,omitempty"`
+	Delivered         bool   `json:"delivered,omitempty"`
+	GroupUnsubscribe  bool   `json:"group_unsubscribe,omitempty"`
+	SpamReport        bool   `json:"spam_report,omitempty"`
+	Bounce            bool   `json:"bounce,omitempty"`
+	Deferred          bool   `json:"deferred,omitempty"`
+	Unsubscribe       bool   `json:"unsubscribe,omitempty"`
+	Processed         bool   `json:"processed,omitempty"`
+	Open              bool   `json:"open,omitempty"`
+	Click             bool   `json:"click,omitempty"`
+	Dropped           bool   `json:"dropped,omitempty"`
+	FriendlyName      string `json:"friendly_name,omitempty"`
+	OAuthClientID     string `json:"oauth_client_id,omitempty"`
+	OAuthClientSecret string `json:"oauth_client_secret,omitempty"`
+	OAuthTokenURL     string `json:"oauth_token_url,omitempty"`
+}
+
+type OutputCreateEventWebhook struct {
+	ID                  string `json:"id,omitempty"`
+	Enabled             bool   `json:"enabled,omitempty"`
+	URL                 string `json:"url,omitempty"`
+	AccountStatusChange bool   `json:"account_status_change,omitempty"`
+	GroupResubscribe    bool   `json:"group_resubscribe,omitempty"`
+	Delivered           bool   `json:"delivered,omitempty"`
+	GroupUnsubscribe    bool   `json:"group_unsubscribe,omitempty"`
+	SpamReport          bool   `json:"spam_report,omitempty"`
+	Bounce              bool   `json:"bounce,omitempty"`
+	Deferred            bool   `json:"deferred,omitempty"`
+	Unsubscribe         bool   `json:"unsubscribe,omitempty"`
+	Processed           bool   `json:"processed,omitempty"`
+	Open                bool   `json:"open,omitempty"`
+	Click               bool   `json:"click,omitempty"`
+	Dropped             bool   `json:"dropped,omitempty"`
+	FriendlyName        string `json:"friendly_name,omitempty"`
+	CreatedDate         string `json:"created_date,omitempty"`
+	UpdatedDate         string `json:"updated_date,omitempty"`
+	OAuthClientID       string `json:"oauth_client_id,omitempty"`
+	OAuthTokenURL       string `json:"oauth_token_url,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/webhooks/create-an-event-webhook
+func (c *Client) CreateEventWebhook(ctx context.Context, input *InputCreateEventWebhook) (*OutputCreateEventWebhook, error) {
+	req, err := c.NewRequest("POST", "/user/webhooks/event/settings", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputCreateEventWebhook)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateEventWebhook struct {
+	Enabled           bool   `json:"enabled,omitempty"`
+	URL               string `json:"url,omitempty"`
+	GroupResubscribe  bool   `json:"group_resubscribe,omitempty"`
+	Delivered         bool   `json:"delivered,omitempty"`
+	GroupUnsubscribe  bool   `json:"group_unsubscribe,omitempty"`
+	SpamReport        bool   `json:"spam_report,omitempty"`
+	Bounce            bool   `json:"bounce,omitempty"`
+	Deferred          bool   `json:"deferred,omitempty"`
+	Unsubscribe       bool   `json:"unsubscribe,omitempty"`
+	Processed         bool   `json:"processed,omitempty"`
+	Open              bool   `json:"open,omitempty"`
+	Click             bool   `json:"click,omitempty"`
+	Dropped           bool   `json:"dropped,omitempty"`
+	FriendlyName      string `json:"friendly_name,omitempty"`
+	OAuthClientID     string `json:"oauth_client_id,omitempty"`
+	OAuthClientSecret string `json:"oauth_client_secret,omitempty"`
+	OAuthTokenURL     string `json:"oauth_token_url,omitempty"`
+}
+
+type OutputUpdateEventWebhook struct {
+	ID               string `json:"id,omitempty"`
+	Enabled          bool   `json:"enabled,omitempty"`
+	URL              string `json:"url,omitempty"`
+	GroupResubscribe bool   `json:"group_resubscribe,omitempty"`
+	Delivered        bool   `json:"delivered,omitempty"`
+	GroupUnsubscribe bool   `json:"group_unsubscribe,omitempty"`
+	SpamReport       bool   `json:"spam_report,omitempty"`
+	Bounce           bool   `json:"bounce,omitempty"`
+	Deferred         bool   `json:"deferred,omitempty"`
+	Unsubscribe      bool   `json:"unsubscribe,omitempty"`
+	Processed        bool   `json:"processed,omitempty"`
+	Open             bool   `json:"open,omitempty"`
+	Click            bool   `json:"click,omitempty"`
+	Dropped          bool   `json:"dropped,omitempty"`
+	FriendlyName     string `json:"friendly_name,omitempty"`
+	CreatedDate      string `json:"created_date,omitempty"`
+	UpdatedDate      string `json:"updated_date,omitempty"`
+	OAuthClientID    string `json:"oauth_client_id,omitempty"`
+	OAuthTokenURL    string `json:"oauth_token_url,omitempty"`
+}
+
+// see: https://docs.sendgrid.com/api-reference/webhooks/update-an-event-webhook
+func (c *Client) UpdateEventWebhook(ctx context.Context, id string, input *InputUpdateEventWebhook) (*OutputUpdateEventWebhook, error) {
+	path := fmt.Sprintf("/user/webhooks/event/settings/%s", id)
+	req, err := c.NewRequest("PATCH", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateEventWebhook)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://docs.sendgrid.com/api-reference/webhooks/delete-an-event-webhook
+func (c *Client) DeleteEventWebhook(ctx context.Context, id string) error {
+	path := fmt.Sprintf("/user/webhooks/event/settings/%s", id)
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/event_webhook_test.go
+++ b/event_webhook_test.go
@@ -1,0 +1,364 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestGetEventWebhook(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings/172af0f9-f165-4172-8a8c-25c16e8e8e25", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": "172af0f9-f165-4172-8a8c-25c16e8e8e25",
+			"enabled": true,
+			"url": "http://www.example.com",
+			"group_resubscribe": true,
+			"delivered": true,
+			"group_unsubscribe": true,
+			"spam_report": true,
+			"bounce": true,
+			"deferred": true,
+			"unsubscribe": true,
+			"processed": true,
+			"open": true,
+			"click": true,
+			"dropped": true,
+			"friendly_name": "example_name"
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetEventWebhook(context.TODO(), "172af0f9-f165-4172-8a8c-25c16e8e8e25")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetEventWebhook{
+		ID:               "172af0f9-f165-4172-8a8c-25c16e8e8e25",
+		Enabled:          true,
+		URL:              "http://www.example.com",
+		GroupResubscribe: true,
+		Delivered:        true,
+		GroupUnsubscribe: true,
+		SpamReport:       true,
+		Bounce:           true,
+		Deferred:         true,
+		Unsubscribe:      true,
+		Processed:        true,
+		Open:             true,
+		Click:            true,
+		Dropped:          true,
+		FriendlyName:     "example_name",
+		OAuthClientID:    "",
+		OAuthTokenURL:    "",
+		PublicKey:        "",
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetEventWebhook_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings/172af0f9-f165-4172-8a8c-25c16e8e8e25", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetEventWebhook(context.TODO(), "172af0f9-f165-4172-8a8c-25c16e8e8e25")
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+}
+
+func TestGetEventWebhooks(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings/all", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"max_allowed": 10,
+			"webhooks": [{
+				"id": "172af0f9-f165-4172-8a8c-25c16e8e8e25",
+				"enabled": true,
+				"url": "http://www.example.com",
+				"group_resubscribe": true,
+				"delivered": true,
+				"group_unsubscribe": true,
+				"spam_report": true,
+				"bounce": true,
+				"deferred": true,
+				"unsubscribe": true,
+				"processed": true,
+				"open": true,
+				"click": true,
+				"dropped": true,
+				"friendly_name": "example_name"
+			}]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetEventWebhooks(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetEventWebhooks{
+		MaxAllowed: 10,
+		Webhooks: []*EventWebhook{
+			{
+				ID:               "172af0f9-f165-4172-8a8c-25c16e8e8e25",
+				Enabled:          true,
+				URL:              "http://www.example.com",
+				GroupResubscribe: true,
+				Delivered:        true,
+				GroupUnsubscribe: true,
+				SpamReport:       true,
+				Bounce:           true,
+				Deferred:         true,
+				Unsubscribe:      true,
+				Processed:        true,
+				Open:             true,
+				Click:            true,
+				Dropped:          true,
+				FriendlyName:     "example_name",
+				OAuthClientID:    "",
+				OAuthTokenURL:    "",
+				PublicKey:        "",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetEventWebhooks_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings/all", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetEventWebhooks(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+}
+
+func TestCreateEventWebhook(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": "172af0f9-f165-4172-8a8c-25c16e8e8e25",
+			"url": "http://www.example.com",
+			"enabled": true,
+			"group_resubscribe": true,
+			"delivered": true,
+			"group_unsubscribe": true,
+			"spam_report": true,
+			"bounce": true,
+			"deferred": true,
+			"unsubscribe": true,
+			"processed": true,
+			"open": true,
+			"click": true,
+			"dropped": true,
+			"friendly_name": "example_name"
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	input := &InputCreateEventWebhook{
+		Enabled:          true,
+		URL:              "http://www.example.com",
+		GroupResubscribe: true,
+		Delivered:        true,
+		GroupUnsubscribe: true,
+		SpamReport:       true,
+		Bounce:           true,
+		Deferred:         true,
+		Unsubscribe:      true,
+		Processed:        true,
+		Open:             true,
+		Click:            true,
+		Dropped:          true,
+		FriendlyName:     "example_name",
+	}
+	expected, err := client.CreateEventWebhook(context.TODO(), input)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputCreateEventWebhook{
+		ID:               "172af0f9-f165-4172-8a8c-25c16e8e8e25",
+		URL:              "http://www.example.com",
+		Enabled:          true,
+		GroupResubscribe: true,
+		Delivered:        true,
+		GroupUnsubscribe: true,
+		SpamReport:       true,
+		Bounce:           true,
+		Deferred:         true,
+		Unsubscribe:      true,
+		Processed:        true,
+		Open:             true,
+		Click:            true,
+		Dropped:          true,
+		FriendlyName:     "example_name",
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestCreateEventWebhook_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	input := &InputCreateEventWebhook{}
+	_, err := client.CreateEventWebhook(context.TODO(), input)
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+}
+
+func TestUpdateEventWebhook(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings/172af0f9-f165-4172-8a8c-25c16e8e8e25", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"id": "172af0f9-f165-4172-8a8c-25c16e8e8e25",
+			"url": "http://www.example.com",
+			"enabled": true,
+			"group_resubscribe": true,
+			"delivered": true,
+			"group_unsubscribe": true,
+			"spam_report": true,
+			"bounce": true,
+			"deferred": true,
+			"unsubscribe": true,
+			"processed": true,
+			"open": true,
+			"click": true,
+			"dropped": true,
+			"friendly_name": "example_name"
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	input := &InputUpdateEventWebhook{
+		Enabled:          true,
+		URL:              "http://www.example.com",
+		GroupResubscribe: true,
+		Delivered:        true,
+		GroupUnsubscribe: true,
+		SpamReport:       true,
+		Bounce:           true,
+		Deferred:         true,
+		Unsubscribe:      true,
+		Processed:        true,
+		Open:             true,
+		Click:            true,
+		Dropped:          true,
+		FriendlyName:     "example_name",
+	}
+	expected, err := client.UpdateEventWebhook(context.TODO(), "172af0f9-f165-4172-8a8c-25c16e8e8e25", input)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateEventWebhook{
+		ID:               "172af0f9-f165-4172-8a8c-25c16e8e8e25",
+		URL:              "http://www.example.com",
+		Enabled:          true,
+		GroupResubscribe: true,
+		Delivered:        true,
+		GroupUnsubscribe: true,
+		SpamReport:       true,
+		Bounce:           true,
+		Deferred:         true,
+		Unsubscribe:      true,
+		Processed:        true,
+		Open:             true,
+		Click:            true,
+		Dropped:          true,
+		FriendlyName:     "example_name",
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateEventWebhook_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings/172af0f9-f165-4172-8a8c-25c16e8e8e25", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	input := &InputUpdateEventWebhook{}
+	_, err := client.UpdateEventWebhook(context.TODO(), "172af0f9-f165-4172-8a8c-25c16e8e8e25", input)
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+}
+
+func TestDeleteEventWebhook(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings/172af0f9-f165-4172-8a8c-25c16e8e8e25", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.DeleteEventWebhook(context.TODO(), "172af0f9-f165-4172-8a8c-25c16e8e8e25")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+}
+
+func TestDeleteEventWebhook_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/event/settings/172af0f9-f165-4172-8a8c-25c16e8e8e25", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := client.DeleteEventWebhook(context.TODO(), "172af0f9-f165-4172-8a8c-25c16e8e8e25")
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+}

--- a/examples/create_event_webhook/main.go
+++ b/examples/create_event_webhook/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.CreateEventWebhook(context.TODO(), &sendgrid.InputCreateEventWebhook{
+		URL: "https://example.com",
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("%#v\n", r)
+
+	return nil
+}


### PR DESCRIPTION
- `GET /v3/user/webhooks/event/settings/{id}`: [Get an Event Webhook](https://docs.sendgrid.com/api-reference/webhooks/get-an-event-webhook)
- `GET /v3/user/webhooks/event/settings/all`: [Get All Event Webhooks](https://docs.sendgrid.com/api-reference/webhooks/get-all-event-webhooks)
- `POST /v3/user/webhooks/event/settings`: [Create an Event Webhook](https://docs.sendgrid.com/api-reference/webhooks/create-an-event-webhook)
- `PATCH /v3/user/webhooks/event/settings/{id}`: [Update an Event Webhook](https://docs.sendgrid.com/api-reference/webhooks/update-an-event-webhook)
- `DELETE /v3/user/webhooks/event/settings/{id}`: [Delete an Event Webhook](https://docs.sendgrid.com/api-reference/webhooks/delete-an-event-webhook)