### PR TITLE
remove omitempty specified in bool type value

### DIFF
--- a/design.go
+++ b/design.go
@@ -77,7 +77,7 @@ type InputCreateDesign struct {
 	Editor               string   `json:"editor,omitempty"`
 	HTMLContent          string   `json:"html_content,omitempty"`
 	PlainContent         string   `json:"plain_content,omitempty"`
-	GeneratePlainContent bool     `json:"generate_plain_content,omitempty"`
+	GeneratePlainContent bool     `json:"generate_plain_content"`
 	Subject              string   `json:"subject,omitempty"`
 	Categories           []string `json:"categories,omitempty"`
 }
@@ -115,7 +115,7 @@ type InputUpdateDesign struct {
 	Name                 string   `json:"name,omitempty"`
 	HTMLContent          string   `json:"html_content,omitempty"`
 	PlainContent         string   `json:"plain_content,omitempty"`
-	GeneratePlainContent bool     `json:"generate_plain_content,omitempty"`
+	GeneratePlainContent bool     `json:"generate_plain_content"`
 	Subject              string   `json:"subject,omitempty"`
 	Categories           []string `json:"categories,omitempty"`
 }

--- a/enforce_tls.go
+++ b/enforce_tls.go
@@ -26,8 +26,8 @@ func (c *Client) GetEnforceTLS(ctx context.Context) (*OutputGetEnforceTLS, error
 }
 
 type InputUpdateEnforceTLS struct {
-	RequireTLS       bool    `json:"require_tls,omitempty"`
-	RequireValidCert bool    `json:"require_valid_cert,omitempty"`
+	RequireTLS       bool    `json:"require_tls"`
+	RequireValidCert bool    `json:"require_valid_cert"`
 	Version          float64 `json:"version,omitempty"`
 }
 

--- a/event_webhook.go
+++ b/event_webhook.go
@@ -85,19 +85,19 @@ func (c *Client) GetEventWebhooks(ctx context.Context) (*OutputGetEventWebhooks,
 }
 
 type InputCreateEventWebhook struct {
-	Enabled           bool   `json:"enabled,omitempty"`
+	Enabled           bool   `json:"enabled"`
 	URL               string `json:"url,omitempty"`
-	GroupResubscribe  bool   `json:"group_resubscribe,omitempty"`
-	Delivered         bool   `json:"delivered,omitempty"`
-	GroupUnsubscribe  bool   `json:"group_unsubscribe,omitempty"`
-	SpamReport        bool   `json:"spam_report,omitempty"`
-	Bounce            bool   `json:"bounce,omitempty"`
-	Deferred          bool   `json:"deferred,omitempty"`
-	Unsubscribe       bool   `json:"unsubscribe,omitempty"`
-	Processed         bool   `json:"processed,omitempty"`
-	Open              bool   `json:"open,omitempty"`
-	Click             bool   `json:"click,omitempty"`
-	Dropped           bool   `json:"dropped,omitempty"`
+	GroupResubscribe  bool   `json:"group_resubscribe"`
+	Delivered         bool   `json:"delivered"`
+	GroupUnsubscribe  bool   `json:"group_unsubscribe"`
+	SpamReport        bool   `json:"spam_report"`
+	Bounce            bool   `json:"bounce"`
+	Deferred          bool   `json:"deferred"`
+	Unsubscribe       bool   `json:"unsubscribe"`
+	Processed         bool   `json:"processed"`
+	Open              bool   `json:"open"`
+	Click             bool   `json:"click"`
+	Dropped           bool   `json:"dropped"`
 	FriendlyName      string `json:"friendly_name,omitempty"`
 	OAuthClientID     string `json:"oauth_client_id,omitempty"`
 	OAuthClientSecret string `json:"oauth_client_secret,omitempty"`
@@ -143,19 +143,19 @@ func (c *Client) CreateEventWebhook(ctx context.Context, input *InputCreateEvent
 }
 
 type InputUpdateEventWebhook struct {
-	Enabled           bool   `json:"enabled,omitempty"`
+	Enabled           bool   `json:"enabled"`
 	URL               string `json:"url,omitempty"`
-	GroupResubscribe  bool   `json:"group_resubscribe,omitempty"`
-	Delivered         bool   `json:"delivered,omitempty"`
-	GroupUnsubscribe  bool   `json:"group_unsubscribe,omitempty"`
-	SpamReport        bool   `json:"spam_report,omitempty"`
-	Bounce            bool   `json:"bounce,omitempty"`
-	Deferred          bool   `json:"deferred,omitempty"`
-	Unsubscribe       bool   `json:"unsubscribe,omitempty"`
-	Processed         bool   `json:"processed,omitempty"`
-	Open              bool   `json:"open,omitempty"`
-	Click             bool   `json:"click,omitempty"`
-	Dropped           bool   `json:"dropped,omitempty"`
+	GroupResubscribe  bool   `json:"group_resubscribe"`
+	Delivered         bool   `json:"delivered"`
+	GroupUnsubscribe  bool   `json:"group_unsubscribe"`
+	SpamReport        bool   `json:"spam_report"`
+	Bounce            bool   `json:"bounce"`
+	Deferred          bool   `json:"deferred"`
+	Unsubscribe       bool   `json:"unsubscribe"`
+	Processed         bool   `json:"processed"`
+	Open              bool   `json:"open"`
+	Click             bool   `json:"click"`
+	Dropped           bool   `json:"dropped"`
 	FriendlyName      string `json:"friendly_name,omitempty"`
 	OAuthClientID     string `json:"oauth_client_id,omitempty"`
 	OAuthClientSecret string `json:"oauth_client_secret,omitempty"`

--- a/examples/create_event_webhook/main.go
+++ b/examples/create_event_webhook/main.go
@@ -19,7 +19,8 @@ func handler() error {
 
 	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
 	r, err := c.CreateEventWebhook(context.TODO(), &sendgrid.InputCreateEventWebhook{
-		URL: "https://example.com",
+		URL:     "https://example.com",
+		Enabled: false,
 	})
 	if err != nil {
 		return err

--- a/inbound_parse_webhook.go
+++ b/inbound_parse_webhook.go
@@ -58,8 +58,8 @@ func (c *Client) GetInboundParseWebhook(ctx context.Context, hostname string) (*
 type InputCreateInboundParseWebhook struct {
 	URL       string `json:"url,omitempty"`
 	Hostname  string `json:"hostname,omitempty"`
-	SpamCheck bool   `json:"spam_check,omitempty"`
-	SendRaw   bool   `json:"send_raw,omitempty"`
+	SpamCheck bool   `json:"spam_check"`
+	SendRaw   bool   `json:"send_raw"`
 }
 
 type OutputCreateInboundParseWebhook struct {
@@ -86,8 +86,8 @@ func (c *Client) CreateInboundParseWebhook(ctx context.Context, input *InputCrea
 
 type InputUpdateInboundParseWebhook struct {
 	URL       string `json:"url,omitempty"`
-	SpamCheck bool   `json:"spam_check,omitempty"`
-	SendRaw   bool   `json:"send_raw,omitempty"`
+	SpamCheck bool   `json:"spam_check"`
+	SendRaw   bool   `json:"send_raw"`
 }
 
 type OutputUpdateInboundParseWebhook struct {

--- a/link_branding.go
+++ b/link_branding.go
@@ -132,7 +132,7 @@ func (c *Client) GetSubuserBrandedLink(ctx context.Context, subuser string) (*Ou
 type InputCreateBrandedLink struct {
 	Domain    string `json:"domain,omitempty"`
 	Subdomain string `json:"subdomain,omitempty"`
-	Default   bool   `json:"default,omitempty"`
+	Default   bool   `json:"default"`
 }
 
 type OutputCreateBrandedLink struct {

--- a/sender_authentication.go
+++ b/sender_authentication.go
@@ -286,8 +286,8 @@ func (c *Client) ValidateDomainAuthentication(ctx context.Context, domainId int6
 }
 
 type InputUpdateDomainAuthentication struct {
-	Default   bool `json:"default,omitempty"`
-	CustomSpf bool `json:"custom_spf,omitempty"`
+	Default   bool `json:"default"`
+	CustomSpf bool `json:"custom_spf"`
 }
 
 type OutputUpdateDomainAuthentication struct {

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"reflect"
@@ -161,6 +162,10 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+
+	b, _ := httputil.DumpRequest(req, true)
+	fmt.Println(string(b))
+
 	return req, nil
 }
 

--- a/sso_certificate.go
+++ b/sso_certificate.go
@@ -57,7 +57,7 @@ func (c *Client) GetSSOCertificates(ctx context.Context, integrationID string) (
 
 type InputCreateSSOCertificate struct {
 	PublicCertificate string `json:"public_certificate,omitempty"`
-	Enabled           bool   `json:"enabled,omitempty"`
+	Enabled           bool   `json:"enabled"`
 	IntegrationID     string `json:"integration_id,omitempty"`
 }
 
@@ -85,7 +85,7 @@ func (c *Client) CreateSSOCertificate(ctx context.Context, input *InputCreateSSO
 
 type InputUpdateSSOCertificate struct {
 	PublicCertificate string `json:"public_certificate,omitempty"`
-	Enabled           bool   `json:"enabled,omitempty"`
+	Enabled           bool   `json:"enabled"`
 	IntegrationID     string `json:"integration_id,omitempty"`
 }
 

--- a/sso_integration.go
+++ b/sso_integration.go
@@ -81,11 +81,11 @@ func (c *Client) GetSSOIntegrations(ctx context.Context, input *InputGetSSOInteg
 
 type InputCreateSSOIntegration struct {
 	Name                 string `json:"name,omitempty"`
-	Enabled              bool   `json:"enabled,omitempty"`
+	Enabled              bool   `json:"enabled"`
 	SigninURL            string `json:"signin_url,omitempty"`
 	SignoutURL           string `json:"signout_url,omitempty"`
 	EntityID             string `json:"entity_id,omitempty"`
-	CompletedIntegration bool   `json:"completed_integration,omitempty"`
+	CompletedIntegration bool   `json:"completed_integration"`
 }
 
 type OutputCreateSSOIntegration struct {
@@ -118,11 +118,11 @@ func (c *Client) CreateSSOIntegration(ctx context.Context, input *InputCreateSSO
 
 type InputUpdateSSOIntegration struct {
 	Name                 string `json:"name,omitempty"`
-	Enabled              bool   `json:"enabled,omitempty"`
+	Enabled              bool   `json:"enabled"`
 	SigninURL            string `json:"signin_url,omitempty"`
 	SignoutURL           string `json:"signout_url,omitempty"`
 	EntityID             string `json:"entity_id,omitempty"`
-	CompletedIntegration bool   `json:"completed_integration,omitempty"`
+	CompletedIntegration bool   `json:"completed_integration"`
 }
 
 type OutputUpdateSSOIntegration struct {

--- a/suppressions_unsubscribe_groups.go
+++ b/suppressions_unsubscribe_groups.go
@@ -50,7 +50,7 @@ func (c *Client) GetSuppressionGroups(ctx context.Context) ([]*SuppressionGroup,
 type InputCreateSuppressionGroup struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	IsDefault   bool   `json:"is_default,omitempty"`
+	IsDefault   bool   `json:"is_default"`
 }
 
 type OutputCreateSuppressionGroup struct {
@@ -77,7 +77,7 @@ func (c *Client) CreateSuppressionGroup(ctx context.Context, input *InputCreateS
 type InputUpdateSuppressionGroup struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	IsDefault   bool   `json:"is_default,omitempty"`
+	IsDefault   bool   `json:"is_default"`
 }
 
 type OutputUpdateSuppressionGroup struct {

--- a/template_version.go
+++ b/template_version.go
@@ -43,7 +43,7 @@ type InputCreateTemplateVersion struct {
 	Name                 string `json:"name,omitempty"`
 	HTMLContent          string `json:"html_content,omitempty"`
 	PlainContent         string `json:"plain_content,omitempty"`
-	GeneratePlainContent bool   `json:"generate_plain_content,omitempty"`
+	GeneratePlainContent bool   `json:"generate_plain_content"`
 	Subject              string `json:"subject,omitempty"`
 	Editor               string `json:"editor,omitempty"`
 	TestData             string `json:"test_data,omitempty"`
@@ -85,7 +85,7 @@ type InputUpdateTemplateVersion struct {
 	Name                 string `json:"name,omitempty"`
 	HTMLContent          string `json:"html_content,omitempty"`
 	PlainContent         string `json:"plain_content,omitempty"`
-	GeneratePlainContent bool   `json:"generate_plain_content,omitempty"`
+	GeneratePlainContent bool   `json:"generate_plain_content"`
 	Subject              string `json:"subject,omitempty"`
 	Editor               string `json:"editor,omitempty"`
 	TestData             string `json:"test_data,omitempty"`

--- a/tracking.go
+++ b/tracking.go
@@ -51,7 +51,7 @@ func (c *Client) GetClickTrackingSettings(ctx context.Context) (*OutputGetClickT
 }
 
 type InputUpdateClickTrackingSettings struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 }
 
 type OutputUpdateClickTrackingSettings struct {
@@ -94,7 +94,7 @@ func (c *Client) GetOpenTrackingSettings(ctx context.Context) (*OutputGetOpenTra
 }
 
 type InputUpdateOpenTrackingSettings struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 }
 
 type OutputUpdateOpenTrackingSettings struct {
@@ -141,7 +141,7 @@ func (c *Client) GetGoogleAnalyticsSettings(ctx context.Context) (*OutputGetGoog
 }
 
 type InputUpdateGoogleAnalyticsSettings struct {
-	Enabled     bool   `json:"enabled,omitempty"`
+	Enabled     bool   `json:"enabled"`
 	UTMCampaign string `json:"utm_campaign,omitempty"`
 	UTMContent  string `json:"utm_content,omitempty"`
 	UTMMedium   string `json:"utm_medium,omitempty"`
@@ -198,7 +198,7 @@ func (c *Client) GetSubscriptionTrackingSettings(ctx context.Context) (*OutputGe
 }
 
 type InputUpdateSubscriptionTrackingSettings struct {
-	Enabled      bool   `json:"enabled,omitempty"`
+	Enabled      bool   `json:"enabled"`
 	HTMLContent  string `json:"html_content,omitempty"`
 	Landing      string `json:"landing,omitempty"`
 	PlainContent string `json:"plain_content,omitempty"`


### PR DESCRIPTION
Remove omitempty for bool type values in Create and Update.

This is because if omitempty is specified and false is specified, it will be omitted and the intended request will not be possible.