### PR TITLE
fix: If the error is in the form ``{"errors": {...}}`` it will not appear in the error message

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -102,18 +102,20 @@ func checkStatusCode(resp *http.Response, d debug) error {
 		return err
 	}
 
+	// {"errors": [{"field": "field name", "message": "error message"}]}
+	errorsResponse := new(ErrorsResponse)
+	if err := newJSONParser(errorsResponse)(resp); err == nil {
+		if errorsResponse.Errs() != nil {
+			return errorsResponse.Errs()
+		}
+	}
+
 	// {"error": "error message"}
 	errorResponse := new(ErrorResponse)
 	if err := newJSONParser(errorResponse)(resp); err == nil {
 		if errorResponse.Err() != nil {
 			return errorResponse.Err()
 		}
-	}
-
-	// {"errors": [{"field": "field name", "message": "error message"}]}
-	errorsResponse := new(ErrorsResponse)
-	if err := newJSONParser(errorsResponse)(resp); err == nil {
-		return errorsResponse.Errs()
 	}
 	return statusCodeError{Code: resp.StatusCode, Status: resp.Status}
 }


### PR DESCRIPTION
Supports the errors format so that you can understand the error details.

## example: error about password

```
c := sendgrid.New(apiKey, sendgrid.OptionDebug(false))
r, err := c.CreateSubuser(context.TODO(), &sendgrid.InputCreateSubuser{
	Username: "kenzo-tanaka",
	Email:    "kenzo.tanaka@example.com",
	Password: "dummydummy",
	Ips:      []string{"1.1.1.1"},
})

if err != nil {
  log.Fatal(err)
}
```

- before: `sendgrid server error: 400 Bad Request`
- after: `field: password, message: Your password must contain at least one character and one number.`