### PR TITLE
chore: Changed the method of obtaining the Go version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Pick golang_info
+      - name: Pick golang version
         id: go
-        run: echo ::set-output name=version::$(grep golang .tool-versions | awk '{print $2}')
+        run: echo "version=$(awk '$1 ~ /^golang/{print $2}' .tool-versions)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Pick golang_info
+      - name: Pick golang version
         id: go
-        run: echo ::set-output name=version::$(grep golang .tool-versions | awk '{print $2}')
+        run: echo "version=$(awk '$1 ~ /^golang/{print $2}' .tool-versions)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Do not use the deprecated `::set-output`.