### PR TITLE
fix Username type in OutputSubuserAccess struct

### DIFF
--- a/teammate.go
+++ b/teammate.go
@@ -295,7 +295,7 @@ type OutputCreateSSOTeammate struct {
 
 type OutputSubuserAccess struct {
 	ID             int64    `json:"id,omitempty"`
-	Username       int64    `json:"username,omitempty"`
+	Username       string    `json:"username,omitempty"`
 	Email          string   `json:"email,omitempty"`
 	Disabled       bool     `json:"disabled,omitempty"`
 	PermissionType string   `json:"permission_type,omitempty"`


### PR DESCRIPTION
The type was int64 instead of being a string