### PR TITLE
Retrieve information for a single SendGrid subuser.

### DIFF
--- a/examples/get_subuser/main.go
+++ b/examples/get_subuser/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/kenzo0107/sendgrid"
+)
+
+func main() {
+	if err := handler(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler() error {
+	apiKey := os.Getenv("SENDGRID_API_KEY")
+
+	c := sendgrid.New(apiKey, sendgrid.OptionDebug(true))
+	r, err := c.GetSubuser(context.TODO(), "dummy")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("subuser: %#v", r)
+	return nil
+}

--- a/subuser.go
+++ b/subuser.go
@@ -20,6 +20,23 @@ type InputGetSubusers struct {
 	Offset   int
 }
 
+// document link not found
+func (c *Client) GetSubuser(ctx context.Context, username string) (*Subuser, error) {
+	path := fmt.Sprintf("/subusers/%s", username)
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(Subuser)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/subusers-api/list-all-subusers
 func (c *Client) GetSubusers(ctx context.Context, input *InputGetSubusers) ([]*Subuser, error) {
 	u, _ := url.Parse("/subusers")
 
@@ -53,6 +70,7 @@ type Reputation struct {
 	Username   string  `json:"username,omitempty"`
 }
 
+// see: https://www.twilio.com/docs/sendgrid/api-reference/subusers-api/retrieve-subuser-reputations
 func (c *Client) GetSubuserReputations(ctx context.Context, usernames string) ([]*Reputation, error) {
 	path := fmt.Sprintf("/subusers/reputations?usernames=%s", usernames)
 
@@ -88,6 +106,7 @@ type CreditAllocation struct {
 	Type string `json:"type"`
 }
 
+// see: https://www.twilio.com/docs/sendgrid/api-reference/subusers-api/create-subuser
 func (c *Client) CreateSubuser(ctx context.Context, input *InputCreateSubuser) (*OutputCreateSubuser, error) {
 	req, err := c.NewRequest("POST", "/subusers", input)
 	if err != nil {
@@ -105,6 +124,7 @@ type InputUpdateSubuserStatus struct {
 	Disabled bool `json:"disabled"`
 }
 
+// see: https://www.twilio.com/docs/sendgrid/api-reference/subusers-api/enabledisable-a-subuser
 func (c *Client) UpdateSubuserStatus(ctx context.Context, username string, input *InputUpdateSubuserStatus) error {
 	path := fmt.Sprintf("/subusers/%s", username)
 
@@ -119,6 +139,7 @@ func (c *Client) UpdateSubuserStatus(ctx context.Context, username string, input
 	return nil
 }
 
+// see: https://www.twilio.com/docs/sendgrid/api-reference/subusers-api/update-ips-assigned-to-a-subuser
 func (c *Client) UpdateSubuserIps(ctx context.Context, username string, ips []string) error {
 	path := fmt.Sprintf("/subusers/%s/ips", username)
 
@@ -133,6 +154,7 @@ func (c *Client) UpdateSubuserIps(ctx context.Context, username string, ips []st
 	return nil
 }
 
+// see: https://www.twilio.com/docs/sendgrid/api-reference/subusers-api/delete-a-subuser
 func (c *Client) DeleteSubuser(ctx context.Context, username string) error {
 	path := fmt.Sprintf("/subusers/%s", username)
 

--- a/subuser_test.go
+++ b/subuser_test.go
@@ -10,6 +10,54 @@ import (
 	"testing"
 )
 
+func TestGetSubuser(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/subusers/testuser", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{
+			"id": 12345,
+			"username": "testuser",
+			"email": "testuser@example.com",
+			"disabled": false
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetSubuser(context.TODO(), "testuser")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &Subuser{
+		ID:       12345,
+		Username: "testuser",
+		Email:    "testuser@example.com",
+		Disabled: false,
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetSubuser_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/subusers/testuser", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetSubuser(context.TODO(), "testuser")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
 func TestGetSubusers(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
@@ -258,6 +306,25 @@ func TestDeleteSubuser_Failed(t *testing.T) {
 }
 
 // NewRequest Error Tests
+func TestGetSubuser_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetSubuser(context.TODO(), "testuser")
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
 func TestGetSubusers_NewRequestError(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
Although this method is not officially documented, it offers significant performance benefits and is therefore adopted.