### PR TITLE
Refactoring of the IP Address / IP Pool / IP Warmup API

### DIFF
--- a/ip_addresses.go
+++ b/ip_addresses.go
@@ -6,54 +6,57 @@ import (
 	"net/url"
 )
 
-// IPAddress represents an IP address
 type IPAddress struct {
-	IP         string   `json:"ip,omitempty"`
-	Pools      []string `json:"pools,omitempty"`
-	Warmup     bool     `json:"warmup,omitempty"`
-	StartDate  int64    `json:"start_date,omitempty"`
-	Subusers   []string `json:"subusers,omitempty"`
-	Rdns       string   `json:"rdns,omitempty"`
-	AssignedAt int64    `json:"assigned_at,omitempty"`
+	IP           string   `json:"ip,omitempty"`
+	Pools        []string `json:"pools,omitempty"`
+	Warmup       bool     `json:"warmup,omitempty"`
+	StartDate    int64    `json:"start_date,omitempty"`
+	Subusers     []string `json:"subusers,omitempty"`
+	Rdns         string   `json:"rdns,omitempty"`
+	AssignedAt   int64    `json:"assigned_at,omitempty"`
+	Whitelabeled bool     `json:"whitelabeled,omitempty"`
 }
 
-// IPPool represents an IP pool
-type IPPool struct {
-	Name string `json:"name,omitempty"`
+type InputGetIPAddresses struct {
+	IP                 string `url:"ip,omitempty"`
+	ExcludeWhitelabels bool   `url:"exclude_whitelabels,omitempty"`
+	Limit              int    `url:"limit,omitempty"`
+	Offset             int    `url:"offset,omitempty"`
+	Subuser            string `url:"subuser,omitempty"`
+	SortByDirection    string `url:"sort_by_direction,omitempty"`
 }
 
-// IPWarmupStatus represents IP warmup status
-type IPWarmupStatus struct {
-	IP     string `json:"ip,omitempty"`
-	Warmup bool   `json:"warmup,omitempty"`
-}
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-address/retrieve-all-ip-addresses
+func (c *Client) GetIPAddresses(ctx context.Context, input *InputGetIPAddresses) ([]*IPAddress, error) {
+	u, _ := url.Parse("/ips")
 
-// InputAddIPToPool represents the request to add an IP to a pool
-type InputAddIPToPool struct {
-	IP string `json:"ip"`
-}
+	q := u.Query()
+	if input.IP != "" {
+		q.Set("ip", input.IP)
+	}
+	if input.ExcludeWhitelabels {
+		q.Set("exclude_whitelabels", fmt.Sprintf("%t", input.ExcludeWhitelabels))
+	}
+	if input.Limit != 0 {
+		q.Set("limit", fmt.Sprintf("%d", input.Limit))
+	}
+	if input.Offset != 0 {
+		q.Set("offset", fmt.Sprintf("%d", input.Offset))
+	}
+	if input.Subuser != "" {
+		q.Set("subuser", input.Subuser)
+	}
+	if input.SortByDirection != "" {
+		q.Set("sort_by_direction", input.SortByDirection)
+	}
+	u.RawQuery = q.Encode()
 
-// InputAssignIPToSubuser represents the request to assign an IP to a subuser
-type InputAssignIPToSubuser struct {
-	IPs []string `json:"ips"`
-}
-
-// OutputAssignedIPs represents the response for assigned IPs
-type OutputAssignedIPs struct {
-	IPs []string `json:"ips,omitempty"`
-}
-
-// GetIPAddresses retrieves all IP addresses
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-addresses/retrieve-all-ip-addresses
-func (c *Client) GetIPAddresses(ctx context.Context) ([]IPAddress, error) {
-	path := "/ips"
-
-	req, err := c.NewRequest("GET", path, nil)
+	req, err := c.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var ips []IPAddress
+	var ips []*IPAddress
 	if err := c.Do(ctx, req, &ips); err != nil {
 		return nil, err
 	}
@@ -61,9 +64,15 @@ func (c *Client) GetIPAddresses(ctx context.Context) ([]IPAddress, error) {
 	return ips, nil
 }
 
-// GetAssignedIPAddresses retrieves all assigned IP addresses
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-addresses/retrieve-all-assigned-ips
-func (c *Client) GetAssignedIPAddresses(ctx context.Context) ([]IPAddress, error) {
+type AssignedIPAddress struct {
+	IP        string   `json:"ip,omitempty"`
+	Pools     []string `json:"pools,omitempty"`
+	Warmup    bool     `json:"warmup,omitempty"`
+	StartDate int64    `json:"start_date,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-address/retrieve-all-assigned-ips
+func (c *Client) GetAssignedIPAddresses(ctx context.Context) ([]*AssignedIPAddress, error) {
 	path := "/ips/assigned"
 
 	req, err := c.NewRequest("GET", path, nil)
@@ -71,7 +80,7 @@ func (c *Client) GetAssignedIPAddresses(ctx context.Context) ([]IPAddress, error
 		return nil, err
 	}
 
-	var ips []IPAddress
+	var ips []*AssignedIPAddress
 	if err := c.Do(ctx, req, &ips); err != nil {
 		return nil, err
 	}
@@ -79,27 +88,43 @@ func (c *Client) GetAssignedIPAddresses(ctx context.Context) ([]IPAddress, error
 	return ips, nil
 }
 
-// GetRemainingIPCount retrieves remaining IP count
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-addresses/retrieve-remaining-ip-count
-func (c *Client) GetRemainingIPCount(ctx context.Context) (map[string]interface{}, error) {
-	path := "/ips/remaining"
+type RemainingIPCount struct {
+	Remaining  int    `json:"remaining,omitempty"`
+	Period     string `json:"period,omitempty"`
+	PricePerIP int    `json:"price_per_ip,omitempty"`
+}
 
-	req, err := c.NewRequest("GET", path, nil)
+type OutputGetRemainingIPCount struct {
+	Results []*RemainingIPCount `json:"results,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-address/get-remaining-ips-count
+func (c *Client) GetRemainingIPCount(ctx context.Context) (*OutputGetRemainingIPCount, error) {
+	req, err := c.NewRequest("GET", "/ips/remaining", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var result map[string]interface{}
-	if err := c.Do(ctx, req, &result); err != nil {
+	r := new(OutputGetRemainingIPCount)
+	if err := c.Do(ctx, req, r); err != nil {
 		return nil, err
 	}
 
-	return result, nil
+	return r, nil
 }
 
-// GetIPAddress retrieves a specific IP address
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-addresses/retrieve-an-ip-address
-func (c *Client) GetIPAddress(ctx context.Context, ip string) (*IPAddress, error) {
+type OutputGetIPAddress struct {
+	IP           string   `json:"ip,omitempty"`
+	Subusers     []string `json:"subusers,omitempty"`
+	Rdns         string   `json:"rdns,omitempty"`
+	Pools        []string `json:"pools,omitempty"`
+	Warmup       bool     `json:"warmup,omitempty"`
+	StartDate    int64    `json:"start_date,omitempty"`
+	Whitelabeled bool     `json:"whitelabeled,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-address/retrieve-all-ip-pools-an-ip-address-belongs-to
+func (c *Client) GetIPAddress(ctx context.Context, ip string) (*OutputGetIPAddress, error) {
 	path := fmt.Sprintf("/ips/%s", url.QueryEscape(ip))
 
 	req, err := c.NewRequest("GET", path, nil)
@@ -107,211 +132,10 @@ func (c *Client) GetIPAddress(ctx context.Context, ip string) (*IPAddress, error
 		return nil, err
 	}
 
-	var ipAddr IPAddress
-	if err := c.Do(ctx, req, &ipAddr); err != nil {
+	r := new(OutputGetIPAddress)
+	if err := c.Do(ctx, req, r); err != nil {
 		return nil, err
 	}
 
-	return &ipAddr, nil
-}
-
-// GetIPPools retrieves all IP pools
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/retrieve-all-ip-pools
-func (c *Client) GetIPPools(ctx context.Context) ([]IPPool, error) {
-	path := "/ips/pools"
-
-	req, err := c.NewRequest("GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var pools []IPPool
-	if err := c.Do(ctx, req, &pools); err != nil {
-		return nil, err
-	}
-
-	return pools, nil
-}
-
-// CreateIPPool creates an IP pool
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/create-an-ip-pool
-func (c *Client) CreateIPPool(ctx context.Context, name string) (*IPPool, error) {
-	path := "/ips/pools"
-
-	input := &IPPool{Name: name}
-
-	req, err := c.NewRequest("POST", path, input)
-	if err != nil {
-		return nil, err
-	}
-
-	var pool IPPool
-	if err := c.Do(ctx, req, &pool); err != nil {
-		return nil, err
-	}
-
-	return &pool, nil
-}
-
-// GetIPPool retrieves a specific IP pool
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/retrieve-an-ip-pool
-func (c *Client) GetIPPool(ctx context.Context, name string) (*IPPool, error) {
-	path := fmt.Sprintf("/ips/pools/%s", url.QueryEscape(name))
-
-	req, err := c.NewRequest("GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var pool IPPool
-	if err := c.Do(ctx, req, &pool); err != nil {
-		return nil, err
-	}
-
-	return &pool, nil
-}
-
-// UpdateIPPool updates an IP pool name
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/update-an-ip-pool
-func (c *Client) UpdateIPPool(ctx context.Context, oldName, newName string) (*IPPool, error) {
-	path := fmt.Sprintf("/ips/pools/%s", url.QueryEscape(oldName))
-
-	input := &IPPool{Name: newName}
-
-	req, err := c.NewRequest("PUT", path, input)
-	if err != nil {
-		return nil, err
-	}
-
-	var pool IPPool
-	if err := c.Do(ctx, req, &pool); err != nil {
-		return nil, err
-	}
-
-	return &pool, nil
-}
-
-// DeleteIPPool deletes an IP pool
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/delete-an-ip-pool
-func (c *Client) DeleteIPPool(ctx context.Context, name string) error {
-	path := fmt.Sprintf("/ips/pools/%s", url.QueryEscape(name))
-
-	req, err := c.NewRequest("DELETE", path, nil)
-	if err != nil {
-		return err
-	}
-
-	if err := c.Do(ctx, req, nil); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AddIPToPool adds an IP address to a pool
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/add-an-ip-address-to-a-pool
-func (c *Client) AddIPToPool(ctx context.Context, poolName, ip string) error {
-	path := fmt.Sprintf("/ips/pools/%s/ips", url.QueryEscape(poolName))
-
-	input := &InputAddIPToPool{IP: ip}
-
-	req, err := c.NewRequest("POST", path, input)
-	if err != nil {
-		return err
-	}
-
-	if err := c.Do(ctx, req, nil); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// RemoveIPFromPool removes an IP address from a pool
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/remove-an-ip-address-from-a-pool
-func (c *Client) RemoveIPFromPool(ctx context.Context, poolName, ip string) error {
-	path := fmt.Sprintf("/ips/pools/%s/ips/%s", url.QueryEscape(poolName), url.QueryEscape(ip))
-
-	req, err := c.NewRequest("DELETE", path, nil)
-	if err != nil {
-		return err
-	}
-
-	if err := c.Do(ctx, req, nil); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// StartIPWarmup starts IP warmup process
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-warmup/start-ip-warmup
-func (c *Client) StartIPWarmup(ctx context.Context, ip string) (*IPWarmupStatus, error) {
-	path := fmt.Sprintf("/ips/warmup/%s", url.QueryEscape(ip))
-
-	req, err := c.NewRequest("POST", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var status IPWarmupStatus
-	if err := c.Do(ctx, req, &status); err != nil {
-		return nil, err
-	}
-
-	return &status, nil
-}
-
-// StopIPWarmup stops IP warmup process
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-warmup/stop-ip-warmup
-func (c *Client) StopIPWarmup(ctx context.Context, ip string) (*IPWarmupStatus, error) {
-	path := fmt.Sprintf("/ips/warmup/%s", url.QueryEscape(ip))
-
-	req, err := c.NewRequest("DELETE", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var status IPWarmupStatus
-	if err := c.Do(ctx, req, &status); err != nil {
-		return nil, err
-	}
-
-	return &status, nil
-}
-
-// GetIPWarmupStatus retrieves IP warmup status
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-warmup/retrieve-ip-warmup-status
-func (c *Client) GetIPWarmupStatus(ctx context.Context, ip string) (*IPWarmupStatus, error) {
-	path := fmt.Sprintf("/ips/warmup/%s", url.QueryEscape(ip))
-
-	req, err := c.NewRequest("GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var status IPWarmupStatus
-	if err := c.Do(ctx, req, &status); err != nil {
-		return nil, err
-	}
-
-	return &status, nil
-}
-
-// GetAllIPWarmupStatus retrieves all IP warmup statuses
-// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-warmup/retrieve-all-ip-warmup-statuses
-func (c *Client) GetAllIPWarmupStatus(ctx context.Context) ([]IPWarmupStatus, error) {
-	path := "/ips/warmup"
-
-	req, err := c.NewRequest("GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var statuses []IPWarmupStatus
-	if err := c.Do(ctx, req, &statuses); err != nil {
-		return nil, err
-	}
-
-	return statuses, nil
+	return r, nil
 }

--- a/ip_addresses_test.go
+++ b/ip_addresses_test.go
@@ -4,369 +4,64 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestIPAddressStruct(t *testing.T) {
-	ip := IPAddress{
-		IP:         "192.168.1.1",
-		Pools:      []string{"pool1", "pool2"},
-		Warmup:     true,
-		StartDate:  1609459200,
-		Subusers:   []string{"subuser1"},
-		Rdns:       "example.com",
-		AssignedAt: 1609459300,
-	}
-
-	assert.Equal(t, "192.168.1.1", ip.IP)
-	assert.Len(t, ip.Pools, 2)
-	assert.Equal(t, "pool1", ip.Pools[0])
-	assert.Equal(t, "pool2", ip.Pools[1])
-	assert.True(t, ip.Warmup)
-	assert.Equal(t, int64(1609459200), ip.StartDate)
-	assert.Len(t, ip.Subusers, 1)
-	assert.Equal(t, "subuser1", ip.Subusers[0])
-	assert.Equal(t, "example.com", ip.Rdns)
-	assert.Equal(t, int64(1609459300), ip.AssignedAt)
-}
-
-func TestIPPoolStruct(t *testing.T) {
-	pool := IPPool{
-		Name: "test-pool",
-	}
-
-	assert.Equal(t, "test-pool", pool.Name)
-}
-
-func TestIPWarmupStatusStruct(t *testing.T) {
-	status := IPWarmupStatus{
-		IP:     "192.168.1.1",
-		Warmup: true,
-	}
-
-	assert.Equal(t, "192.168.1.1", status.IP)
-	assert.True(t, status.Warmup)
-}
-
-func TestInputAddIPToPoolStruct(t *testing.T) {
-	input := InputAddIPToPool{
-		IP: "192.168.1.1",
-	}
-
-	assert.Equal(t, "192.168.1.1", input.IP)
-}
-
-func TestInputAssignIPToSubuserStruct(t *testing.T) {
-	input := InputAssignIPToSubuser{
-		IPs: []string{"192.168.1.1", "192.168.1.2"},
-	}
-
-	assert.Len(t, input.IPs, 2)
-	assert.Equal(t, "192.168.1.1", input.IPs[0])
-	assert.Equal(t, "192.168.1.2", input.IPs[1])
-}
-
-func TestOutputAssignedIPsStruct(t *testing.T) {
-	output := OutputAssignedIPs{
-		IPs: []string{"192.168.1.1", "192.168.1.2"},
-	}
-
-	assert.Len(t, output.IPs, 2)
-	assert.Equal(t, "192.168.1.1", output.IPs[0])
-	assert.Equal(t, "192.168.1.2", output.IPs[1])
-}
 
 func TestGetIPAddresses(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
 	mux.HandleFunc("/ips", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"ip":"192.168.1.1","pools":["pool1"],"warmup":true,"start_date":1609459200,"subusers":["subuser1"],"rdns":"example.com","assigned_at":1609459300}]`))
+		_, _ = w.Write([]byte(`[
+			{
+				"ip":"192.168.1.1",
+				"pools":["pool1"],
+				"warmup":true,
+				"start_date":1609459200,
+				"subusers":["subuser1"],
+				"rdns":"example.com",
+				"assigned_at":1609459300
+			}]`))
 	})
 
 	ctx := context.Background()
-	ips, err := client.GetIPAddresses(ctx)
-
-	assert.NoError(t, err)
-	assert.Len(t, ips, 1)
-	assert.Equal(t, "192.168.1.1", ips[0].IP)
-	assert.Equal(t, []string{"pool1"}, ips[0].Pools)
-	assert.True(t, ips[0].Warmup)
-	assert.Equal(t, int64(1609459200), ips[0].StartDate)
-	assert.Equal(t, []string{"subuser1"}, ips[0].Subusers)
-	assert.Equal(t, "example.com", ips[0].Rdns)
-	assert.Equal(t, int64(1609459300), ips[0].AssignedAt)
-}
-
-func TestGetAssignedIPAddresses(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/assigned", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"ip":"192.168.1.1","pools":["pool1"],"warmup":false}]`))
+	expected, err := client.GetIPAddresses(ctx, &InputGetIPAddresses{
+		IP:                 "192.168.1.1",
+		ExcludeWhitelabels: true,
+		Limit:              100,
+		Offset:             10,
+		Subuser:            "subuser1",
+		SortByDirection:    "asc",
 	})
+	if err != nil {
+		assert.Fail(t, "GetIPAddresses returned an error: %v", err)
+		return
+	}
 
-	ctx := context.Background()
-	ips, err := client.GetAssignedIPAddresses(ctx)
+	want := []*IPAddress{{
+		IP:           "192.168.1.1",
+		Pools:        []string{"pool1"},
+		Warmup:       true,
+		StartDate:    1609459200,
+		Subusers:     []string{"subuser1"},
+		Rdns:         "example.com",
+		AssignedAt:   1609459300,
+		Whitelabeled: false,
+	}}
 
-	assert.NoError(t, err)
-	assert.Len(t, ips, 1)
-	assert.Equal(t, "192.168.1.1", ips[0].IP)
-	assert.Equal(t, []string{"pool1"}, ips[0].Pools)
-	assert.False(t, ips[0].Warmup)
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
 }
 
-func TestGetRemainingIPCount(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/remaining", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"remaining":5,"total":10}`))
-	})
-
-	ctx := context.Background()
-	result, err := client.GetRemainingIPCount(ctx)
-
-	assert.NoError(t, err)
-	assert.Equal(t, float64(5), result["remaining"])
-	assert.Equal(t, float64(10), result["total"])
-}
-
-func TestGetIPAddress(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ip":"192.168.1.1","pools":["pool1"],"warmup":true,"rdns":"example.com"}`))
-	})
-
-	ctx := context.Background()
-	ip, err := client.GetIPAddress(ctx, "192.168.1.1")
-
-	assert.NoError(t, err)
-	assert.Equal(t, "192.168.1.1", ip.IP)
-	assert.Equal(t, []string{"pool1"}, ip.Pools)
-	assert.True(t, ip.Warmup)
-	assert.Equal(t, "example.com", ip.Rdns)
-}
-
-func TestGetIPPools(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"name":"pool1"},{"name":"pool2"}]`))
-	})
-
-	ctx := context.Background()
-	pools, err := client.GetIPPools(ctx)
-
-	assert.NoError(t, err)
-	assert.Len(t, pools, 2)
-	assert.Equal(t, "pool1", pools[0].Name)
-	assert.Equal(t, "pool2", pools[1].Name)
-}
-
-func TestCreateIPPool(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"name":"new-pool"}`))
-	})
-
-	ctx := context.Background()
-	pool, err := client.CreateIPPool(ctx, "new-pool")
-
-	assert.NoError(t, err)
-	assert.Equal(t, "new-pool", pool.Name)
-}
-
-func TestGetIPPool(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/test-pool", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"name":"test-pool"}`))
-	})
-
-	ctx := context.Background()
-	pool, err := client.GetIPPool(ctx, "test-pool")
-
-	assert.NoError(t, err)
-	assert.Equal(t, "test-pool", pool.Name)
-}
-
-func TestUpdateIPPool(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/old-pool", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"name":"new-pool"}`))
-	})
-
-	ctx := context.Background()
-	pool, err := client.UpdateIPPool(ctx, "old-pool", "new-pool")
-
-	assert.NoError(t, err)
-	assert.Equal(t, "new-pool", pool.Name)
-}
-
-func TestDeleteIPPool(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/test-pool", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	ctx := context.Background()
-	err := client.DeleteIPPool(ctx, "test-pool")
-
-	assert.NoError(t, err)
-}
-
-func TestAddIPToPool(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/test-pool/ips", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		w.WriteHeader(http.StatusCreated)
-	})
-
-	ctx := context.Background()
-	err := client.AddIPToPool(ctx, "test-pool", "192.168.1.1")
-
-	assert.NoError(t, err)
-}
-
-func TestRemoveIPFromPool(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/test-pool/ips/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	ctx := context.Background()
-	err := client.RemoveIPFromPool(ctx, "test-pool", "192.168.1.1")
-
-	assert.NoError(t, err)
-}
-
-func TestStartIPWarmup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ip":"192.168.1.1","warmup":true}`))
-	})
-
-	ctx := context.Background()
-	status, err := client.StartIPWarmup(ctx, "192.168.1.1")
-
-	assert.NoError(t, err)
-	assert.Equal(t, "192.168.1.1", status.IP)
-	assert.True(t, status.Warmup)
-}
-
-func TestStopIPWarmup(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ip":"192.168.1.1","warmup":false}`))
-	})
-
-	ctx := context.Background()
-	status, err := client.StopIPWarmup(ctx, "192.168.1.1")
-
-	assert.NoError(t, err)
-	assert.Equal(t, "192.168.1.1", status.IP)
-	assert.False(t, status.Warmup)
-}
-
-func TestGetIPWarmupStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ip":"192.168.1.1","warmup":true}`))
-	})
-
-	ctx := context.Background()
-	status, err := client.GetIPWarmupStatus(ctx, "192.168.1.1")
-
-	assert.NoError(t, err)
-	assert.Equal(t, "192.168.1.1", status.IP)
-	assert.True(t, status.Warmup)
-}
-
-func TestGetAllIPWarmupStatus(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"ip":"192.168.1.1","warmup":true},{"ip":"192.168.1.2","warmup":false}]`))
-	})
-
-	ctx := context.Background()
-	statuses, err := client.GetAllIPWarmupStatus(ctx)
-
-	assert.NoError(t, err)
-	assert.Len(t, statuses, 2)
-	assert.Equal(t, "192.168.1.1", statuses[0].IP)
-	assert.True(t, statuses[0].Warmup)
-	assert.Equal(t, "192.168.1.2", statuses[1].IP)
-	assert.False(t, statuses[1].Warmup)
-}
-
-// Error cases for IP addresses
 func TestGetIPAddresses_Failed(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
-
 	mux.HandleFunc("/ips", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -374,15 +69,64 @@ func TestGetIPAddresses_Failed(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	_, err := client.GetIPAddresses(ctx)
-
+	_, err := client.GetIPAddresses(ctx, &InputGetIPAddresses{})
 	assert.Error(t, err)
+}
+
+func TestGetIPAddresses_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	_, err := client.GetIPAddresses(ctx, &InputGetIPAddresses{Limit: -1})
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetAssignedIPAddresses(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/assigned", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`[
+			{
+				"ip":"192.168.1.1",
+				"pools":["pool1"],
+				"warmup":true,
+				"start_date":1609459200
+			}]`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+
+	})
+
+	ctx := context.Background()
+	expected, err := client.GetAssignedIPAddresses(ctx)
+	if err != nil {
+		assert.Fail(t, "GetAssignedIPAddresses returned an error: %v", err)
+		return
+	}
+
+	want := []*AssignedIPAddress{{
+		IP:        "192.168.1.1",
+		Pools:     []string{"pool1"},
+		Warmup:    true,
+		StartDate: 1609459200,
+	}}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
 }
 
 func TestGetAssignedIPAddresses_Failed(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
-
 	mux.HandleFunc("/ips/assigned", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -391,14 +135,65 @@ func TestGetAssignedIPAddresses_Failed(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := client.GetAssignedIPAddresses(ctx)
-
 	assert.Error(t, err)
+}
+
+func TestGetAssignedIPAddresses_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	_, err := client.GetAssignedIPAddresses(ctx)
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetRemainingIPCount(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/remaining", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{
+			"results":[
+				{
+					"remaining":5,
+					"period":"month",
+					"price_per_ip":100
+				}
+			]
+		}`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	expected, err := client.GetRemainingIPCount(ctx)
+	if err != nil {
+		assert.Fail(t, "GetRemainingIPCount returned an error: %v", err)
+		return
+	}
+
+	want := &OutputGetRemainingIPCount{
+		Results: []*RemainingIPCount{{
+			Remaining:  5,
+			Period:     "month",
+			PricePerIP: 100,
+		}},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
 }
 
 func TestGetRemainingIPCount_Failed(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
-
 	mux.HandleFunc("/ips/remaining", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -407,367 +202,79 @@ func TestGetRemainingIPCount_Failed(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := client.GetRemainingIPCount(ctx)
-
 	assert.Error(t, err)
+}
+
+func TestGetRemainingIPCount_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	_, err := client.GetRemainingIPCount(ctx)
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetIPAddress(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{
+			"ip":"192.168.1.1",
+			"pools":["pool1"],
+			"warmup":true,
+			"start_date":1609459200,
+			"subusers":["subuser1"],
+			"rdns":"example.com",
+			"whitelabeled":false
+		}`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	expected, err := client.GetIPAddress(ctx, "192.168.1.1")
+	if err != nil {
+		assert.Fail(t, "GetIPAddress returned an error: %v", err)
+		return
+	}
+
+	want := &OutputGetIPAddress{
+		IP:           "192.168.1.1",
+		Pools:        []string{"pool1"},
+		Warmup:       true,
+		StartDate:    1609459200,
+		Subusers:     []string{"subuser1"},
+		Rdns:         "example.com",
+		Whitelabeled: false,
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
 }
 
 func TestGetIPAddress_Failed(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
-
-	mux.HandleFunc("/ips/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/ips/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error": "IP address not found"}`))
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
 	})
 
 	ctx := context.Background()
 	_, err := client.GetIPAddress(ctx, "192.168.1.1")
-
 	assert.Error(t, err)
 }
 
-func TestGetIPPools_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
-	})
-
-	ctx := context.Background()
-	_, err := client.GetIPPools(ctx)
-
-	assert.Error(t, err)
-}
-
-func TestCreateIPPool_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error": "Invalid pool name"}`))
-	})
-
-	ctx := context.Background()
-	_, err := client.CreateIPPool(ctx, "invalid-pool")
-
-	assert.Error(t, err)
-}
-
-func TestGetIPPool_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/test-pool", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error": "Pool not found"}`))
-	})
-
-	ctx := context.Background()
-	_, err := client.GetIPPool(ctx, "test-pool")
-
-	assert.Error(t, err)
-}
-
-func TestUpdateIPPool_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/old-pool", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error": "Pool not found"}`))
-	})
-
-	ctx := context.Background()
-	_, err := client.UpdateIPPool(ctx, "old-pool", "new-pool")
-
-	assert.Error(t, err)
-}
-
-func TestDeleteIPPool_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/test-pool", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error": "Pool not found"}`))
-	})
-
-	ctx := context.Background()
-	err := client.DeleteIPPool(ctx, "test-pool")
-
-	assert.Error(t, err)
-}
-
-func TestAddIPToPool_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/test-pool/ips", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error": "Invalid IP address"}`))
-	})
-
-	ctx := context.Background()
-	err := client.AddIPToPool(ctx, "test-pool", "invalid-ip")
-
-	assert.Error(t, err)
-}
-
-func TestRemoveIPFromPool_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/test-pool/ips/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error": "IP not found in pool"}`))
-	})
-
-	ctx := context.Background()
-	err := client.RemoveIPFromPool(ctx, "test-pool", "192.168.1.1")
-
-	assert.Error(t, err)
-}
-
-func TestStartIPWarmup_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error": "IP already in warmup"}`))
-	})
-
-	ctx := context.Background()
-	_, err := client.StartIPWarmup(ctx, "192.168.1.1")
-
-	assert.Error(t, err)
-}
-
-func TestStopIPWarmup_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error": "IP not in warmup"}`))
-	})
-
-	ctx := context.Background()
-	_, err := client.StopIPWarmup(ctx, "192.168.1.1")
-
-	assert.Error(t, err)
-}
-
-func TestGetIPWarmupStatus_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/192.168.1.1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error": "IP not found"}`))
-	})
-
-	ctx := context.Background()
-	_, err := client.GetIPWarmupStatus(ctx, "192.168.1.1")
-
-	assert.Error(t, err)
-}
-
-func TestGetAllIPWarmupStatus_Failed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
-	})
-
-	ctx := context.Background()
-	_, err := client.GetAllIPWarmupStatus(ctx)
-
-	assert.Error(t, err)
-}
-
-// URL escaping tests
-func TestGetIPAddress_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ip":"192.168.1.1/24","pools":["pool1"]}`))
-	})
-
-	ctx := context.Background()
-	ip, err := client.GetIPAddress(ctx, "192.168.1.1/24")
-
-	assert.NoError(t, err)
-	assert.NotNil(t, ip)
-	assert.Equal(t, "192.168.1.1/24", ip.IP)
-}
-
-func TestGetIPPool_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"name":"pool name"}`))
-	})
-
-	ctx := context.Background()
-	pool, err := client.GetIPPool(ctx, "pool name")
-
-	assert.NoError(t, err)
-	assert.NotNil(t, pool)
-	assert.Equal(t, "pool name", pool.Name)
-}
-
-func TestUpdateIPPool_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"name":"new pool"}`))
-	})
-
-	ctx := context.Background()
-	pool, err := client.UpdateIPPool(ctx, "old pool", "new pool")
-
-	assert.NoError(t, err)
-	assert.NotNil(t, pool)
-	assert.Equal(t, "new pool", pool.Name)
-}
-
-func TestDeleteIPPool_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	ctx := context.Background()
-	err := client.DeleteIPPool(ctx, "test pool")
-
-	assert.NoError(t, err)
-}
-
-func TestAddIPToPool_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		w.WriteHeader(http.StatusCreated)
-	})
-
-	ctx := context.Background()
-	err := client.AddIPToPool(ctx, "test pool", "192.168.1.1")
-
-	assert.NoError(t, err)
-}
-
-func TestRemoveIPFromPool_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/pools/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	ctx := context.Background()
-	err := client.RemoveIPFromPool(ctx, "test pool", "192.168.1.1/24")
-
-	assert.NoError(t, err)
-}
-
-func TestStartIPWarmup_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ip":"192.168.1.1/24","warmup":true}`))
-	})
-
-	ctx := context.Background()
-	status, err := client.StartIPWarmup(ctx, "192.168.1.1/24")
-
-	assert.NoError(t, err)
-	assert.NotNil(t, status)
-	assert.Equal(t, "192.168.1.1/24", status.IP)
-	assert.True(t, status.Warmup)
-}
-
-func TestStopIPWarmup_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ip":"192.168.1.1/24","warmup":false}`))
-	})
-
-	ctx := context.Background()
-	status, err := client.StopIPWarmup(ctx, "192.168.1.1/24")
-
-	assert.NoError(t, err)
-	assert.NotNil(t, status)
-	assert.Equal(t, "192.168.1.1/24", status.IP)
-	assert.False(t, status.Warmup)
-}
-
-func TestGetIPWarmupStatus_URLEscape(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips/warmup/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ip":"192.168.1.1/24","warmup":true}`))
-	})
-
-	ctx := context.Background()
-	status, err := client.GetIPWarmupStatus(ctx, "192.168.1.1/24")
-
-	assert.NoError(t, err)
-	assert.NotNil(t, status)
-	assert.Equal(t, "192.168.1.1/24", status.IP)
-	assert.True(t, status.Warmup)
-}
-
-// NewRequest Error Tests for IP Address methods
-func TestGetIPAddresses_NewRequestError(t *testing.T) {
+func TestGetIPAddress_NewRequestFailed(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
@@ -775,219 +282,9 @@ func TestGetIPAddresses_NewRequestError(t *testing.T) {
 	invalidURL, _ := url.Parse("https://api.example.com/v3/")
 	client.baseURL = invalidURL
 
-	_, err := client.GetIPAddresses(context.TODO())
+	ctx := context.Background()
+	_, err := client.GetIPAddress(ctx, "192.168.1.1")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestGetAssignedIPAddresses_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.GetAssignedIPAddresses(context.TODO())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestGetRemainingIPCount_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.GetRemainingIPCount(context.TODO())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestGetIPAddress_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.GetIPAddress(context.TODO(), "192.168.1.1")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestGetIPPools_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.GetIPPools(context.TODO())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestCreateIPPool_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.CreateIPPool(context.TODO(), "test-pool")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestGetIPPool_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.GetIPPool(context.TODO(), "test-pool")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestUpdateIPPool_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.UpdateIPPool(context.TODO(), "old-pool", "new-pool")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestDeleteIPPool_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	err := client.DeleteIPPool(context.TODO(), "test-pool")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestAddIPToPool_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	err := client.AddIPToPool(context.TODO(), "test-pool", "192.168.1.1")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestRemoveIPFromPool_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	err := client.RemoveIPFromPool(context.TODO(), "test-pool", "192.168.1.1")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestStartIPWarmup_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.StartIPWarmup(context.TODO(), "192.168.1.1")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestStopIPWarmup_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.StopIPWarmup(context.TODO(), "192.168.1.1")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestGetIPWarmupStatus_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.GetIPWarmupStatus(context.TODO(), "192.168.1.1")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
-
-	client.baseURL = originalBaseURL
-}
-
-func TestGetAllIPWarmupStatus_NewRequestError(t *testing.T) {
-	client, _, _, teardown := setup()
-	defer teardown()
-
-	originalBaseURL := client.baseURL
-	invalidURL, _ := url.Parse("https://api.example.com/v3/")
-	client.baseURL = invalidURL
-
-	_, err := client.GetAllIPWarmupStatus(context.TODO())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "trailing slash")
 
 	client.baseURL = originalBaseURL
 }

--- a/ip_pool.go
+++ b/ip_pool.go
@@ -1,0 +1,159 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// IPPool represents an IP pool
+type IPPool struct {
+	Name string `json:"name,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/retrieve-all-ip-pools
+func (c *Client) GetIPPools(ctx context.Context) ([]*IPPool, error) {
+	path := "/ips/pools"
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var pools []*IPPool
+	if err := c.Do(ctx, req, &pools); err != nil {
+		return nil, err
+	}
+
+	return pools, nil
+}
+
+type OutputGetIPPool struct {
+	Name string   `json:"name,omitempty"`
+	IPs  []string `json:"ips,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/retrieve-all-the-ips-in-a-specified-pool
+func (c *Client) GetIPPool(ctx context.Context, name string) (*OutputGetIPPool, error) {
+	path := fmt.Sprintf("/ips/pools/%s", url.QueryEscape(name))
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetIPPool)
+	if err := c.Do(ctx, req, r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputCreateIPPool struct {
+	Name string `json:"name,omitempty"`
+}
+
+type OutputCreateIPPool struct {
+	Name string `json:"name,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/create-an-ip-pool
+func (c *Client) CreateIPPool(ctx context.Context, input *InputCreateIPPool) (*OutputCreateIPPool, error) {
+	req, err := c.NewRequest("POST", "/ips/pools", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputCreateIPPool)
+	if err := c.Do(ctx, req, r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateIPPool struct {
+	Name string `json:"name,omitempty"`
+}
+
+type OutputUpdateIPPool struct {
+	Name string `json:"name,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/rename-an-ip-pool
+func (c *Client) UpdateIPPool(ctx context.Context, name string, input *InputUpdateIPPool) (*OutputUpdateIPPool, error) {
+	path := fmt.Sprintf("/ips/pools/%s", url.QueryEscape(name))
+
+	req, err := c.NewRequest("PUT", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateIPPool)
+	if err := c.Do(ctx, req, r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/delete-an-ip-pool
+func (c *Client) DeleteIPPool(ctx context.Context, name string) error {
+	path := fmt.Sprintf("/ips/pools/%s", url.QueryEscape(name))
+
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type InputAddIPToPool struct {
+	IP string `json:"ip"`
+}
+
+type OutputAddIPToPool struct {
+	IP        string   `json:"ip,omitempty"`
+	Pools     []string `json:"pools,omitempty"`
+	Warmup    bool     `json:"warmup,omitempty"`
+	StartDate int64    `json:"start_date,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/add-an-ip-address-to-a-pool
+func (c *Client) AddIPToPool(ctx context.Context, poolName string, input *InputAddIPToPool) (*OutputAddIPToPool, error) {
+	path := fmt.Sprintf("/ips/pools/%s/ips", url.QueryEscape(poolName))
+
+	req, err := c.NewRequest("POST", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputAddIPToPool)
+	if err := c.Do(ctx, req, r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/remove-an-ip-address-from-a-pool
+func (c *Client) RemoveIPFromPool(ctx context.Context, poolName, ip string) error {
+	path := fmt.Sprintf("/ips/pools/%s/ips/%s", url.QueryEscape(poolName), url.QueryEscape(ip))
+
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/ip_pool_test.go
+++ b/ip_pool_test.go
@@ -1,0 +1,396 @@
+package sendgrid
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIPPools(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`[
+			{"name":"pool1"},
+			{"name":"pool2"}
+		]`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	expected, err := client.GetIPPools(ctx)
+	if err != nil {
+		assert.Fail(t, "GetIPPools returned an error: %v", err)
+		return
+	}
+
+	want := []*IPPool{
+		{Name: "pool1"},
+		{Name: "pool2"},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestTestGetIPPools_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
+	})
+
+	ctx := context.Background()
+	_, err := client.GetIPPools(ctx)
+	assert.Error(t, err)
+}
+
+func TestTestGetIPPools_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	_, err := client.GetIPPools(ctx)
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetIPPool(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{
+			"name":"pool1",
+			"ips":[
+				"192.168.0.1",
+				"192.168.0.2"
+			]
+		}`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	expected, err := client.GetIPPool(ctx, "pool1")
+	if err != nil {
+		assert.Fail(t, "GetIPPool returned an error: %v", err)
+		return
+	}
+
+	want := &OutputGetIPPool{
+		Name: "pool1",
+		IPs:  []string{"192.168.0.1", "192.168.0.2"},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetIPPool_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
+	})
+
+	ctx := context.Background()
+	_, err := client.GetIPPool(ctx, "pool1")
+	assert.Error(t, err)
+}
+
+func TestGetIPPool_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	_, err := client.GetIPPool(ctx, "pool1")
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestCreateIPPool(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{
+			"name":"pool1"
+		}`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	input := &InputCreateIPPool{Name: "pool1"}
+	expected, err := client.CreateIPPool(ctx, input)
+	if err != nil {
+		assert.Fail(t, "CreateIPPool returned an error: %v", err)
+		return
+	}
+
+	want := &OutputCreateIPPool{Name: "pool1"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestCreateIPPool_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
+	})
+
+	ctx := context.Background()
+	input := &InputCreateIPPool{Name: "pool1"}
+	_, err := client.CreateIPPool(ctx, input)
+	assert.Error(t, err)
+}
+
+func TestCreateIPPool_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	input := &InputCreateIPPool{Name: "pool1"}
+	_, err := client.CreateIPPool(ctx, input)
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestUpdateIPPool(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{
+			"name":"pool1"
+		}`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	input := &InputUpdateIPPool{Name: "pool1"}
+	expected, err := client.UpdateIPPool(ctx, "pool1", input)
+	if err != nil {
+		assert.Fail(t, "UpdateIPPool returned an error: %v", err)
+		return
+	}
+
+	want := &OutputUpdateIPPool{Name: "pool1"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateIPPool_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
+	})
+
+	ctx := context.Background()
+	input := &InputUpdateIPPool{Name: "pool1"}
+	_, err := client.UpdateIPPool(ctx, "pool1", input)
+	assert.Error(t, err)
+}
+
+func TestUpdateIPPool_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	input := &InputUpdateIPPool{Name: "pool1"}
+	_, err := client.UpdateIPPool(ctx, "pool1", input)
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestDeleteIPPool(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	err := client.DeleteIPPool(ctx, "pool1")
+	if err != nil {
+		assert.Fail(t, "DeleteIPPool returned an error: %v", err)
+	}
+}
+
+func TestDeleteIPPool_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
+	})
+
+	ctx := context.Background()
+	err := client.DeleteIPPool(ctx, "pool1")
+	assert.Error(t, err)
+}
+
+func TestDeleteIPPool_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	err := client.DeleteIPPool(ctx, "pool1")
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestAddIPToPool(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1/ips", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{
+			"ip":"192.168.0.1"
+		}`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	input := &InputAddIPToPool{IP: "192.168.0.1"}
+	expected, err := client.AddIPToPool(ctx, "pool1", input)
+	if err != nil {
+		assert.Fail(t, "AddIPToPool returned an error: %v", err)
+		return
+	}
+
+	want := &OutputAddIPToPool{IP: "192.168.0.1"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestAddIPToPool_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1/ips", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
+	})
+
+	ctx := context.Background()
+	input := &InputAddIPToPool{IP: "192.168.0.1"}
+	_, err := client.AddIPToPool(ctx, "pool1", input)
+	assert.Error(t, err)
+}
+
+func TestAddIPToPool_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	input := &InputAddIPToPool{IP: "192.168.0.1"}
+	_, err := client.AddIPToPool(ctx, "pool1", input)
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestRemoveIPFromPool(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1/ips/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	err := client.RemoveIPFromPool(ctx, "pool1", "192.168.0.1")
+	if err != nil {
+		assert.Fail(t, "RemoveIPFromPool returned an error: %v", err)
+	}
+}
+
+func TestRemoveIPFromPool_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/pools/pool1/ips/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal server error"}`))
+	})
+
+	ctx := context.Background()
+	err := client.RemoveIPFromPool(ctx, "pool1", "192.168.0.1")
+	assert.Error(t, err)
+}
+
+func TestRemoveIPFromPool_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	err := client.RemoveIPFromPool(ctx, "pool1", "192.168.0.1")
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}

--- a/ip_warmup.go
+++ b/ip_warmup.go
@@ -1,0 +1,79 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+type InputStartIPWarmup struct {
+	IP string `json:"ip"`
+}
+
+type IPWarmup struct {
+	IP        string `json:"ip,omitempty"`
+	StartDate int64  `json:"start_date,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-warmup/start-warming-up-an-ip-address
+func (c *Client) StartIPWarmup(ctx context.Context, input *InputStartIPWarmup) ([]*IPWarmup, error) {
+	req, err := c.NewRequest("POST", "/ips/warmup", input)
+	if err != nil {
+		return nil, err
+	}
+
+	var r []*IPWarmup
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-warmup/stop-warming-up-an-ip-address
+func (c *Client) StopIPWarmup(ctx context.Context, ip string) error {
+	path := fmt.Sprintf("/ips/warmup/%s", url.QueryEscape(ip))
+
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-warmup/retrieve-ip-warmup-status
+func (c *Client) GetIPWarmupStatus(ctx context.Context, ip string) ([]*IPWarmup, error) {
+	path := fmt.Sprintf("/ips/warmup/%s", url.QueryEscape(ip))
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var r []*IPWarmup
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/ip-warmup/retrieve-all-ips-currently-in-warmup
+func (c *Client) GetAllIPWarmup(ctx context.Context) ([]*IPWarmup, error) {
+	req, err := c.NewRequest("GET", "/ips/warmup", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var r []*IPWarmup
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/ip_warmup_test.go
+++ b/ip_warmup_test.go
@@ -1,0 +1,231 @@
+package sendgrid
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartIPWarmup(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/warmup", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`[
+			{"ip":"192.168.0.1", "start_date":1700000000}
+		]`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	expected, err := client.StartIPWarmup(ctx, &InputStartIPWarmup{IP: "192.168.0.1"})
+	if err != nil {
+		assert.Fail(t, "StartIPWarmup returned an error: %v", err)
+	}
+
+	want := []*IPWarmup{
+		{IP: "192.168.0.1", StartDate: 1700000000},
+	}
+
+	if !assert.Equal(t, want, expected) {
+		assert.Fail(t, "StartIPWarmup returned unexpected result: got %v, want %v", expected, want)
+	}
+}
+
+func TestStartIPWarmup_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/warmup", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	})
+
+	ctx := context.Background()
+	_, err := client.StartIPWarmup(ctx, &InputStartIPWarmup{IP: "192.168.0.1"})
+	if err == nil {
+		assert.Fail(t, "Expected error, got nil")
+	}
+}
+
+func TestStartIPWarmup_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	_, err := client.StartIPWarmup(ctx, nil)
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestStopIPWarmup(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/warmup/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ctx := context.Background()
+	err := client.StopIPWarmup(ctx, "192.168.0.1")
+	if err != nil {
+		assert.Fail(t, "StopIPWarmup returned an error: %v", err)
+	}
+}
+
+func TestStopIPWarmup_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/warmup/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	})
+
+	ctx := context.Background()
+	err := client.StopIPWarmup(ctx, "192.168.0.1")
+	assert.Error(t, err)
+}
+
+func TestStopIPWarmup_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	err := client.StopIPWarmup(ctx, "192.168.0.1")
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetIPWarmupStatus(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/warmup/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`[
+			{"ip":"192.168.0.1", "start_date":1700000000}
+		]`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	status, err := client.GetIPWarmupStatus(ctx, "192.168.0.1")
+	if err != nil {
+		assert.Fail(t, "GetIPWarmupStatus returned an error: %v", err)
+	}
+
+	want := []*IPWarmup{
+		{
+			IP:        "192.168.0.1",
+			StartDate: 1700000000,
+		},
+	}
+
+	if !assert.Equal(t, want, status) {
+		assert.Fail(t, "GetIPWarmupStatus returned unexpected result: got %v, want %v", status, want)
+	}
+}
+
+func TestGetIPWarmupStatus_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/warmup/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	})
+
+	ctx := context.Background()
+	_, err := client.GetIPWarmupStatus(ctx, "192.168.0.1")
+	assert.Error(t, err)
+}
+
+func TestGetIPWarmupStatus_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	_, err := client.GetIPWarmupStatus(ctx, "192.168.0.1")
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetAllIPWarmup(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/warmup", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`[
+			{"ip":"192.168.0.1", "start_date":1700000000},
+			{"ip":"192.168.0.2", "start_date":1700000001}
+		]`)); err != nil {
+			assert.Fail(t, "Failed to write response: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	status, err := client.GetAllIPWarmup(ctx)
+	if err != nil {
+		assert.Fail(t, "GetAllIPWarmup returned an error: %v", err)
+	}
+
+	want := []*IPWarmup{
+		{
+			IP:        "192.168.0.1",
+			StartDate: 1700000000,
+		},
+		{
+			IP:        "192.168.0.2",
+			StartDate: 1700000001,
+		},
+	}
+
+	if !assert.Equal(t, want, status) {
+		assert.Fail(t, "GetAllIPWarmup returned unexpected result: got %v, want %v", status, want)
+	}
+}
+
+func TestGetAllIPWarmup_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/ips/warmup", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	})
+
+	ctx := context.Background()
+	_, err := client.GetAllIPWarmup(ctx)
+	assert.Error(t, err)
+}
+
+func TestGetAllIPWarmup_NewRequestFailed(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	ctx := context.Background()
+	_, err := client.GetAllIPWarmup(ctx)
+	assert.Error(t, err)
+
+	client.baseURL = originalBaseURL
+}


### PR DESCRIPTION
- Improved structure and method signatures for the IP Address API, including support for query parameters and additional response types
- Separated the IP Pool API into ip_pool.go and added Input/Output structs
- Separated the IP Warmup API into ip_warmup.go and modified the struct structure to comply with API documentation standards
- Unified tests into three categories: normal operation, abnormal conditions, and NewRequestError scenarios