### PR TITLE
Changed the IPs field in GetIPPool from a string array to an IP struct

### DIFF
--- a/examples/get_ip_pool/main.go
+++ b/examples/get_ip_pool/main.go
@@ -22,6 +22,10 @@ func handler() error {
 	if err != nil {
 		return err
 	}
-	log.Printf("%#v\n", r)
+	log.Printf("pool name: %#v\n", r.PoolName)
+
+	for _, ip := range r.IPs {
+		log.Printf("%#v\n", ip)
+	}
 	return nil
 }

--- a/ip_pool.go
+++ b/ip_pool.go
@@ -28,9 +28,15 @@ func (c *Client) GetIPPools(ctx context.Context) ([]*IPPool, error) {
 	return pools, nil
 }
 
+type IP struct {
+	IP        string `json:"ip,omitempty"`
+	Warmup    bool   `json:"warmup,omitempty"`
+	StartDate int64  `json:"start_date,omitempty"`
+}
+
 type OutputGetIPPool struct {
-	PoolName string   `json:"pool_name,omitempty"`
-	IPs      []string `json:"ips,omitempty"`
+	PoolName string `json:"pool_name,omitempty"`
+	IPs      []*IP  `json:"ips,omitempty"`
 }
 
 // see: https://www.twilio.com/docs/sendgrid/api-reference/ip-pools/retrieve-all-the-ips-in-a-specified-pool

--- a/ip_pool_test.go
+++ b/ip_pool_test.go
@@ -79,8 +79,8 @@ func TestGetIPPool(t *testing.T) {
 		if _, err := w.Write([]byte(`{
 			"pool_name":"pool1",
 			"ips":[
-				"192.168.0.1",
-				"192.168.0.2"
+				{"ip":"192.168.0.1", "warmup":true, "start_date":1700000000},
+				{"ip":"192.168.0.2", "warmup":false, "start_date":1700000000}
 			]
 		}`)); err != nil {
 			assert.Fail(t, "Failed to write response: %v", err)
@@ -96,7 +96,10 @@ func TestGetIPPool(t *testing.T) {
 
 	want := &OutputGetIPPool{
 		PoolName: "pool1",
-		IPs:      []string{"192.168.0.1", "192.168.0.2"},
+		IPs: []*IP{
+			{IP: "192.168.0.1", Warmup: true, StartDate: 1700000000},
+			{IP: "192.168.0.2", Warmup: false, StartDate: 1700000000},
+		},
 	}
 
 	if !reflect.DeepEqual(want, expected) {


### PR DESCRIPTION
- Added IP struct with fields: ip, warmup, and start_date
- Modified the type of OutputGetIPPool.IPs from []string to []*IP
- Updated test mock responses and assertions
- Modified sample code to display detailed IP information