### PR TITLE
Add region-specific base URL constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ func main() {
 }
 ```
 
+### Using EU Region
+
+```go
+	// When using an EU region
+	c := sendgrid.New(apiKey, sendgrid.OptionBaseURL(sendgrid.BaseURLEU))
+```
+
 ## License
 
 [MIT License](https://github.com/kenzo0107/sendgrid/blob/main/LICENSE)

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -17,7 +17,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-var defaultBaseURL, _ = url.Parse("https://api.sendgrid.com/v3")
+const (
+	// BaseURLGlobal は Global リージョンの base URL です
+	BaseURLGlobal = "https://api.sendgrid.com/v3"
+	// BaseURLEU は EU リージョンの base URL です
+	BaseURLEU = "https://api.eu.sendgrid.com/v3"
+)
+
+var defaultBaseURL, _ = url.Parse(BaseURLGlobal)
 
 // httpClient defines the minimal interface needed for an http.Client to be implemented.
 type httpClient interface {

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -83,6 +83,37 @@ func TestOptionSubuser(t *testing.T) {
 	}
 }
 
+func TestOptionBaseURL_WithRegions(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseURL     string
+		expectedURL string
+	}{
+		{
+			name:        "Global region",
+			baseURL:     BaseURLGlobal,
+			expectedURL: "https://api.sendgrid.com/v3",
+		},
+		{
+			name:        "EU region",
+			baseURL:     BaseURLEU,
+			expectedURL: "https://api.eu.sendgrid.com/v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := New("test-api-key")
+			option := OptionBaseURL(tt.baseURL)
+			option(client)
+
+			if client.baseURL.String() != tt.expectedURL {
+				t.Errorf("Expected baseURL to be '%s', got %s", tt.expectedURL, client.baseURL.String())
+			}
+		})
+	}
+}
+
 func TestOptionHTTPClient(t *testing.T) {
 	client := New("test-api-key")
 	customClient := &http.Client{}


### PR DESCRIPTION
- Added `BaseURLGlobal` and `BaseURLEU` constants
- Enabled region specification via `OptionBaseURL`
- Added test case `TestOptionBaseURL_WithRegions`
- Added EU region usage examples to the README