### PR TITLE
Add mail settings and webhook security policy APIs

### DIFF
--- a/mail_settings.go
+++ b/mail_settings.go
@@ -1,0 +1,269 @@
+package sendgrid
+
+import (
+	"context"
+)
+
+type MailSetting struct {
+	Title       string `json:"title,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type InputGetMailSettings struct {
+	Limit  int `url:"limit,omitempty"`
+	Offset int `url:"offset,omitempty"`
+}
+
+type OutputGetMailSettings struct {
+	Result []*MailSetting `json:"result,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/retrieve-all-mail-settings
+func (c *Client) GetMailSettings(ctx context.Context, input *InputGetMailSettings) (*OutputGetMailSettings, error) {
+	path, err := c.AddOptions("/mail_settings", input)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetAddressWhitelistMailSettings struct {
+	Enabled bool     `json:"enabled"`
+	List    []string `json:"list,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/retrieve-address-whitelist-mail-settings
+func (c *Client) GetAddressWhitelistMailSettings(ctx context.Context) (*OutputGetAddressWhitelistMailSettings, error) {
+	req, err := c.NewRequest("GET", "/mail_settings/address_whitelist", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetAddressWhitelistMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateAddressWhitelistMailSettings struct {
+	Enabled bool     `json:"enabled"`
+	List    []string `json:"list,omitempty"`
+}
+
+type OutputUpdateAddressWhitelistMailSettings struct {
+	Enabled bool     `json:"enabled"`
+	List    []string `json:"list,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/update-address-whitelist-mail-settings
+func (c *Client) UpdateAddressWhitelistMailSettings(ctx context.Context, input *InputUpdateAddressWhitelistMailSettings) (*OutputUpdateAddressWhitelistMailSettings, error) {
+	req, err := c.NewRequest("PATCH", "/mail_settings/address_whitelist", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateAddressWhitelistMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetFooterMailSettings struct {
+	Enabled      bool   `json:"enabled"`
+	HTMLContent  string `json:"html_content,omitempty"`
+	PlainContent string `json:"plain_content,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/retrieve-footer-mail-settings
+func (c *Client) GetFooterMailSettings(ctx context.Context) (*OutputGetFooterMailSettings, error) {
+	req, err := c.NewRequest("GET", "/mail_settings/footer", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetFooterMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateFooterMailSettings struct {
+	Enabled      bool   `json:"enabled"`
+	HTMLContent  string `json:"html_content,omitempty"`
+	PlainContent string `json:"plain_content,omitempty"`
+}
+
+type OutputUpdateFooterMailSettings struct {
+	Enabled      bool   `json:"enabled"`
+	HTMLContent  string `json:"html_content,omitempty"`
+	PlainContent string `json:"plain_content,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/update-footer-mail-settings
+func (c *Client) UpdateFooterMailSettings(ctx context.Context, input *InputUpdateFooterMailSettings) (*OutputUpdateFooterMailSettings, error) {
+	req, err := c.NewRequest("PATCH", "/mail_settings/footer", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateFooterMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetForwardBounceMailSettings struct {
+	Enabled bool   `json:"enabled"`
+	Email   string `json:"email,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/retrieve-forward-bounce-mail-settings
+func (c *Client) GetForwardBounceMailSettings(ctx context.Context) (*OutputGetForwardBounceMailSettings, error) {
+	req, err := c.NewRequest("GET", "/mail_settings/forward_bounce", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetForwardBounceMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateForwardBounceMailSettings struct {
+	Enabled bool   `json:"enabled"`
+	Email   string `json:"email,omitempty"`
+}
+
+type OutputUpdateForwardBounceMailSettings struct {
+	Enabled bool   `json:"enabled"`
+	Email   string `json:"email,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/update-forward-bounce-mail-settings
+func (c *Client) UpdateForwardBounceMailSettings(ctx context.Context, input *InputUpdateForwardBounceMailSettings) (*OutputUpdateForwardBounceMailSettings, error) {
+	req, err := c.NewRequest("PATCH", "/mail_settings/forward_bounce", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateForwardBounceMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetForwardSpamMailSettings struct {
+	Enabled bool   `json:"enabled"`
+	Email   string `json:"email,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/retrieve-forward-spam-mail-settings
+func (c *Client) GetForwardSpamMailSettings(ctx context.Context) (*OutputGetForwardSpamMailSettings, error) {
+	req, err := c.NewRequest("GET", "/mail_settings/forward_spam", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetForwardSpamMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateForwardSpamMailSettings struct {
+	Enabled bool   `json:"enabled"`
+	Email   string `json:"email,omitempty"`
+}
+
+type OutputUpdateForwardSpamMailSettings struct {
+	Enabled bool   `json:"enabled"`
+	Email   string `json:"email,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/update-forward-spam-mail-settings
+func (c *Client) UpdateForwardSpamMailSettings(ctx context.Context, input *InputUpdateForwardSpamMailSettings) (*OutputUpdateForwardSpamMailSettings, error) {
+	req, err := c.NewRequest("PATCH", "/mail_settings/forward_spam", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateForwardSpamMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetTemplateMailSettings struct {
+	Enabled     bool   `json:"enabled"`
+	HTMLContent string `json:"html_content,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/retrieve-legacy-template-mail-settings
+func (c *Client) GetTemplateMailSettings(ctx context.Context) (*OutputGetTemplateMailSettings, error) {
+	req, err := c.NewRequest("GET", "/mail_settings/template", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetTemplateMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateTemplateMailSettings struct {
+	Enabled     bool   `json:"enabled"`
+	HTMLContent string `json:"html_content,omitempty"`
+}
+
+type OutputUpdateTemplateMailSettings struct {
+	Enabled     bool   `json:"enabled"`
+	HTMLContent string `json:"html_content,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/mail-settings/update-template-mail-settings
+func (c *Client) UpdateTemplateMailSettings(ctx context.Context, input *InputUpdateTemplateMailSettings) (*OutputUpdateTemplateMailSettings, error) {
+	req, err := c.NewRequest("PATCH", "/mail_settings/template", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateTemplateMailSettings)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/mail_settings_test.go
+++ b/mail_settings_test.go
@@ -1,0 +1,665 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestGetMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{
+			"result": [
+				{"title": "Address Whitelist", "enabled": true, "name": "address_whitelist", "description": "desc"}
+			]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetMailSettings(context.TODO(), &InputGetMailSettings{})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetMailSettings{
+		Result: []*MailSetting{
+			{Title: "Address Whitelist", Enabled: true, Name: "address_whitelist", Description: "desc"},
+		},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetMailSettings(context.TODO(), &InputGetMailSettings{})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetMailSettings(context.TODO(), &InputGetMailSettings{})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetAddressWhitelistMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/address_whitelist", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "list": ["email1@example.com"]}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetAddressWhitelistMailSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetAddressWhitelistMailSettings{Enabled: true, List: []string{"email1@example.com"}}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetAddressWhitelistMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/address_whitelist", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetAddressWhitelistMailSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetAddressWhitelistMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetAddressWhitelistMailSettings(context.TODO())
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestUpdateAddressWhitelistMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/address_whitelist", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "list": ["email1@example.com"]}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateAddressWhitelistMailSettings(context.TODO(), &InputUpdateAddressWhitelistMailSettings{
+		Enabled: true,
+		List:    []string{"email1@example.com"},
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateAddressWhitelistMailSettings{Enabled: true, List: []string{"email1@example.com"}}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateAddressWhitelistMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/address_whitelist", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateAddressWhitelistMailSettings(context.TODO(), &InputUpdateAddressWhitelistMailSettings{Enabled: true})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateAddressWhitelistMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.UpdateAddressWhitelistMailSettings(context.TODO(), &InputUpdateAddressWhitelistMailSettings{Enabled: true})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetFooterMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/footer", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "html_content": "<p>html</p>", "plain_content": "plain"}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetFooterMailSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetFooterMailSettings{Enabled: true, HTMLContent: "<p>html</p>", PlainContent: "plain"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetFooterMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/footer", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetFooterMailSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetFooterMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetFooterMailSettings(context.TODO())
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestUpdateFooterMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/footer", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "html_content": "<p>html</p>", "plain_content": "plain"}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateFooterMailSettings(context.TODO(), &InputUpdateFooterMailSettings{
+		Enabled:      true,
+		HTMLContent:  "<p>html</p>",
+		PlainContent: "plain",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateFooterMailSettings{Enabled: true, HTMLContent: "<p>html</p>", PlainContent: "plain"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateFooterMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/footer", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateFooterMailSettings(context.TODO(), &InputUpdateFooterMailSettings{Enabled: true})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateFooterMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.UpdateFooterMailSettings(context.TODO(), &InputUpdateFooterMailSettings{Enabled: true})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetForwardBounceMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/forward_bounce", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "email": "email@example.com"}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetForwardBounceMailSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetForwardBounceMailSettings{Enabled: true, Email: "email@example.com"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetForwardBounceMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/forward_bounce", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetForwardBounceMailSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetForwardBounceMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetForwardBounceMailSettings(context.TODO())
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestUpdateForwardBounceMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/forward_bounce", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "email": "email@example.com"}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateForwardBounceMailSettings(context.TODO(), &InputUpdateForwardBounceMailSettings{
+		Enabled: true,
+		Email:   "email@example.com",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateForwardBounceMailSettings{Enabled: true, Email: "email@example.com"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateForwardBounceMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/forward_bounce", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateForwardBounceMailSettings(context.TODO(), &InputUpdateForwardBounceMailSettings{Enabled: true})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateForwardBounceMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.UpdateForwardBounceMailSettings(context.TODO(), &InputUpdateForwardBounceMailSettings{Enabled: true})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetForwardSpamMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/forward_spam", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "email": "email@example.com"}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetForwardSpamMailSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetForwardSpamMailSettings{Enabled: true, Email: "email@example.com"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetForwardSpamMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/forward_spam", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetForwardSpamMailSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetForwardSpamMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetForwardSpamMailSettings(context.TODO())
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestUpdateForwardSpamMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/forward_spam", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "email": "email@example.com"}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateForwardSpamMailSettings(context.TODO(), &InputUpdateForwardSpamMailSettings{
+		Enabled: true,
+		Email:   "email@example.com",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateForwardSpamMailSettings{Enabled: true, Email: "email@example.com"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateForwardSpamMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/forward_spam", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateForwardSpamMailSettings(context.TODO(), &InputUpdateForwardSpamMailSettings{Enabled: true})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateForwardSpamMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.UpdateForwardSpamMailSettings(context.TODO(), &InputUpdateForwardSpamMailSettings{Enabled: true})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetTemplateMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/template", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{"enabled": false, "html_content": "<p><% body %>Example</p>\n"}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetTemplateMailSettings(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetTemplateMailSettings{HTMLContent: "<p><% body %>Example</p>\n"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetTemplateMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/template", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetTemplateMailSettings(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetTemplateMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetTemplateMailSettings(context.TODO())
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestUpdateTemplateMailSettings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/template", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		if _, err := fmt.Fprint(w, `{"enabled": true, "html_content": "<p>html</p>"}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateTemplateMailSettings(context.TODO(), &InputUpdateTemplateMailSettings{
+		Enabled:     true,
+		HTMLContent: "<p>html</p>",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateTemplateMailSettings{Enabled: true, HTMLContent: "<p>html</p>"}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateTemplateMailSettings_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/mail_settings/template", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateTemplateMailSettings(context.TODO(), &InputUpdateTemplateMailSettings{Enabled: true})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateTemplateMailSettings_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.UpdateTemplateMailSettings(context.TODO(), &InputUpdateTemplateMailSettings{Enabled: true})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}

--- a/webhook_security_policy.go
+++ b/webhook_security_policy.go
@@ -1,0 +1,133 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+)
+
+type WebhookSecurityPolicyOAuth struct {
+	ClientID     string   `json:"client_id,omitempty"`
+	ClientSecret string   `json:"client_secret,omitempty"`
+	TokenURL     string   `json:"token_url,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
+}
+
+type WebhookSecurityPolicySignature struct {
+	Enabled   bool   `json:"enabled,omitempty"`
+	PublicKey string `json:"public_key,omitempty"`
+}
+
+type WebhookSecurityPolicy struct {
+	ID        string                          `json:"id,omitempty"`
+	Name      string                          `json:"name,omitempty"`
+	OAuth     *WebhookSecurityPolicyOAuth     `json:"oauth,omitempty"`
+	Signature *WebhookSecurityPolicySignature `json:"signature,omitempty"`
+}
+
+type InputCreateWebhookSecurityPolicy struct {
+	Name      string                          `json:"name,omitempty"`
+	OAuth     *WebhookSecurityPolicyOAuth     `json:"oauth,omitempty"`
+	Signature *WebhookSecurityPolicySignature `json:"signature,omitempty"`
+}
+
+type OutputCreateWebhookSecurityPolicy struct {
+	Policy *WebhookSecurityPolicy `json:"policy,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/webhook-security-policies/create-a-new-webhook-security-policy
+func (c *Client) CreateWebhookSecurityPolicy(ctx context.Context, input *InputCreateWebhookSecurityPolicy) (*OutputCreateWebhookSecurityPolicy, error) {
+	req, err := c.NewRequest("POST", "/user/webhooks/security/policies", input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputCreateWebhookSecurityPolicy)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetWebhookSecurityPolicies struct {
+	Policies []*WebhookSecurityPolicy `json:"policies,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/webhook-security-policies/retrieve-all-webhook-security-policies-for-your-account
+func (c *Client) GetWebhookSecurityPolicies(ctx context.Context) (*OutputGetWebhookSecurityPolicies, error) {
+	req, err := c.NewRequest("GET", "/user/webhooks/security/policies", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetWebhookSecurityPolicies)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type OutputGetWebhookSecurityPolicy struct {
+	Policy *WebhookSecurityPolicy `json:"policy,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/webhook-security-policies/retrieve-a-specific-webhook-security-policy
+func (c *Client) GetWebhookSecurityPolicy(ctx context.Context, id string) (*OutputGetWebhookSecurityPolicy, error) {
+	path := fmt.Sprintf("/user/webhooks/security/policies/%s", id)
+
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputGetWebhookSecurityPolicy)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+type InputUpdateWebhookSecurityPolicy struct {
+	Name      string                          `json:"name,omitempty"`
+	OAuth     *WebhookSecurityPolicyOAuth     `json:"oauth,omitempty"`
+	Signature *WebhookSecurityPolicySignature `json:"signature,omitempty"`
+}
+
+type OutputUpdateWebhookSecurityPolicy struct {
+	Policy *WebhookSecurityPolicy `json:"policy,omitempty"`
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/webhook-security-policies/update-an-existing-webhook-security-policy
+func (c *Client) UpdateWebhookSecurityPolicy(ctx context.Context, id string, input *InputUpdateWebhookSecurityPolicy) (*OutputUpdateWebhookSecurityPolicy, error) {
+	path := fmt.Sprintf("/user/webhooks/security/policies/%s", id)
+
+	req, err := c.NewRequest("PATCH", path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	r := new(OutputUpdateWebhookSecurityPolicy)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// see: https://www.twilio.com/docs/sendgrid/api-reference/webhook-security-policies/delete-a-specific-webhook-security-policy
+func (c *Client) DeleteWebhookSecurityPolicy(ctx context.Context, id string) error {
+	path := fmt.Sprintf("/user/webhooks/security/policies/%s", id)
+
+	req, err := c.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/webhook_security_policy_test.go
+++ b/webhook_security_policy_test.go
@@ -1,0 +1,341 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func TestCreateWebhookSecurityPolicy(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		if _, err := fmt.Fprint(w, `{
+			"policy": {
+				"id": "policy-1",
+				"name": "test policy",
+				"oauth": {
+					"client_id": "client-id",
+					"token_url": "https://example.com/token",
+					"scopes": ["scope1"]
+				},
+				"signature": {
+					"public_key": "public-key"
+				}
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.CreateWebhookSecurityPolicy(context.TODO(), &InputCreateWebhookSecurityPolicy{
+		Name: "test policy",
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputCreateWebhookSecurityPolicy{
+		Policy: &WebhookSecurityPolicy{
+			ID:   "policy-1",
+			Name: "test policy",
+			OAuth: &WebhookSecurityPolicyOAuth{
+				ClientID: "client-id",
+				TokenURL: "https://example.com/token",
+				Scopes:   []string{"scope1"},
+			},
+			Signature: &WebhookSecurityPolicySignature{
+				PublicKey: "public-key",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestCreateWebhookSecurityPolicy_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.CreateWebhookSecurityPolicy(context.TODO(), &InputCreateWebhookSecurityPolicy{Name: "test policy"})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateWebhookSecurityPolicy_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.CreateWebhookSecurityPolicy(context.TODO(), &InputCreateWebhookSecurityPolicy{Name: "test policy"})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetWebhookSecurityPolicies(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{
+			"policies": [
+				{
+					"id": "policy-1",
+					"name": "test policy"
+				}
+			]
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetWebhookSecurityPolicies(context.TODO())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetWebhookSecurityPolicies{
+		Policies: []*WebhookSecurityPolicy{
+			{ID: "policy-1", Name: "test policy"},
+		},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetWebhookSecurityPolicies_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetWebhookSecurityPolicies(context.TODO())
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetWebhookSecurityPolicies_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetWebhookSecurityPolicies(context.TODO())
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetWebhookSecurityPolicy(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies/policy-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if _, err := fmt.Fprint(w, `{
+			"policy": {
+				"id": "policy-1",
+				"name": "test policy"
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetWebhookSecurityPolicy(context.TODO(), "policy-1")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputGetWebhookSecurityPolicy{
+		Policy: &WebhookSecurityPolicy{ID: "policy-1", Name: "test policy"},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetWebhookSecurityPolicy_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies/policy-1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetWebhookSecurityPolicy(context.TODO(), "policy-1")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetWebhookSecurityPolicy_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetWebhookSecurityPolicy(context.TODO(), "policy-1")
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestUpdateWebhookSecurityPolicy(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies/policy-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		if _, err := fmt.Fprint(w, `{
+			"policy": {
+				"id": "policy-1",
+				"name": "updated policy"
+			}
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateWebhookSecurityPolicy(context.TODO(), "policy-1", &InputUpdateWebhookSecurityPolicy{Name: "updated policy"})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &OutputUpdateWebhookSecurityPolicy{
+		Policy: &WebhookSecurityPolicy{ID: "policy-1", Name: "updated policy"},
+	}
+
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateWebhookSecurityPolicy_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies/policy-1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateWebhookSecurityPolicy(context.TODO(), "policy-1", &InputUpdateWebhookSecurityPolicy{Name: "updated policy"})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateWebhookSecurityPolicy_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	_, err := client.UpdateWebhookSecurityPolicy(context.TODO(), "policy-1", &InputUpdateWebhookSecurityPolicy{Name: "updated policy"})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestDeleteWebhookSecurityPolicy(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies/policy-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := client.DeleteWebhookSecurityPolicy(context.TODO(), "policy-1"); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+}
+
+func TestDeleteWebhookSecurityPolicy_Failed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/webhooks/security/policies/policy-1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if err := client.DeleteWebhookSecurityPolicy(context.TODO(), "policy-1"); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteWebhookSecurityPolicy_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://api.example.com/v3/")
+	client.baseURL = invalidURL
+
+	err := client.DeleteWebhookSecurityPolicy(context.TODO(), "policy-1")
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}


### PR DESCRIPTION
- Add mail settings API: address whitelist, footer, forward bounce, forward spam, and template settings
- Add webhook security policy API: create, list, get, update, and delete